### PR TITLE
Ensure DISABLE_SIGNUPS Variable Handles Boolean Values Correctly

### DIFF
--- a/packages/api/src/app/constants.ts
+++ b/packages/api/src/app/constants.ts
@@ -21,7 +21,7 @@ export const JWT_SECRET = validateEnv("JWT_SECRET");
 export const NODE_ENV = validateEnv<"development" | "production">("NODE_ENV", "production");
 
 export const REDIS_URL = validateEnv("REDIS_URL");
-export const DISABLE_SIGNUPS = validateEnv<"true" | "false">("DISABLE_SIGNUPS", "false") === "true";
+export const DISABLE_SIGNUPS = validateEnv("DISABLE_SIGNUPS", "false").toLowerCase() === "true";
 
 // URLs
 export const API_URI = validateEnv("API_URI", "http://localhost:4000");


### PR DESCRIPTION
This pull request makes the following changes to ensure the `DISABLE_SIGNUPS` variable is handled correctly as a Boolean value:

1. **Standardizes the handling of the `DISABLE_SIGNUPS` variable** to be case-insensitive and default to `false` if not set.

**Changes Made:**

- **constants.ts:**
  Changed the conversion of the `DISABLE_SIGNUPS` variable to handle case insensitivity and default to `false` if not set:
  ```typescript
  export const DISABLE_SIGNUPS = validateEnv("DISABLE_SIGNUPS", "false").toLowerCase() === "true";

**Reason for Changes:**
To ensure that the DISABLE_SIGNUPS variable is correctly interpreted as a Boolean value (true or false), regardless of its case.

**Testing:**
Verified that the application correctly defaults to allowing signups if the DISABLE_SIGNUPS variable is not set.
Tested various cases (e.g., true, TRUE, false, FALSE) to ensure the variable is correctly interpreted.

This pull request addresses issue #14.

