### PR TITLE
Fix NaN display issue on Analytics page when no data is available

### DIFF
--- a/packages/dashboard/src/pages/analytics/index.tsx
+++ b/packages/dashboard/src/pages/analytics/index.tsx
@@ -65,7 +65,12 @@ export default function Index() {
 								<div>
 									<p className={"font-medium text-neutral-600"}>Bounce Rate</p>
 									<p className={"text-2xl font-semibold text-neutral-800"}>
-										<>{((analytics.emails.bounced / analytics.emails.total) * 100).toFixed(2)}%</>
+                  {Number.isNaN(
+                    (analytics.emails.bounced / analytics.emails.total) * 100)
+                      ? 0
+                      : (
+                          (analytics.emails.bounced / analytics.emails.total) * 100).toFixed(2)}
+                     %
 									</p>
 								</div>
 								<div className={"flex flex-1 justify-end"}>
@@ -123,8 +128,13 @@ export default function Index() {
 								<div>
 									<p className={"font-medium text-neutral-600"}>Spam Rate</p>
 									<p className={"text-2xl font-semibold text-neutral-800"}>
-										<>{((analytics.emails.complaint / analytics.emails.total) * 100).toFixed(2)}%</>
-									</p>
+                  {Number.isNaN(
+                    (analytics.emails.complaint / analytics.emails.total) * 100)
+                      ? 0
+                      : (
+                          (analytics.emails.complaint / analytics.emails.total) * 100).toFixed(2)}
+                     %									
+                  </p>
 								</div>
 								<div className={"flex flex-1 justify-end"}>
 									{analytics.emails.complaint / analytics.emails.total >


### PR DESCRIPTION
**Description**
This pull request addresses the issue of displaying NaN on the Analytics page when no data is available. The changes include:

Implemented checks to handle cases where data might be missing or zero, preventing NaN from being shown.
Updated relevant calculations to default to 0 when invalid or missing data is encountered.

**Changes Made**
Added conditional checks to ensure calculations result in valid numbers.
Modified the display logic to show 0 instead of NaN when data is not available.
Impact