### PR TITLE
Use Nginx's recommendation for HTTP 1.1 and websockets

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -9,6 +9,9 @@ http {
         location /api/ {
             proxy_pass http://127.0.0.1:4000/;
             proxy_set_header Host $host;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -17,6 +20,9 @@ http {
         location / {
             proxy_pass http://127.0.0.1:5000;
             proxy_set_header Host $host;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
While I was poking around the Nginx config I saw that Next.js prefers the following options to be set for APIs. I did it for both just because if the client doesn't pass the upgrade request it isn't used.