### PR TITLE
Wrap Prisma and IORedis in a try/catch with logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,40 @@
 {
-	"name": "plunk",
-	"version": "1.0.2",
-	"private": true,
-	"license": "agpl-3.0",
-	"workspaces": {
-		"packages": ["packages/*"]
-	},
-	"engines": {
-		"npm": ">=6.14.x",
-		"yarn": "1.22.x",
-		"node": ">=18.x"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.8.3",
-		"lerna": "^8.1.6",
-		"prisma": "^5.17.0",
-		"rimraf": "^5.0.9"
-	},
-	"dependencies": {
-		"@prisma/client": "^5.17.0"
-	},
-	"scripts": {
-		"dev:api": "yarn workspace @plunk/api dev",
-		"dev:dashboard": "yarn workspace @plunk/dashboard dev",
-		"dev:shared": "yarn workspace @plunk/shared dev",
-		"build:api": "yarn build:shared && yarn workspace @plunk/api build",
-		"build:dashboard": "yarn build:shared && yarn workspace @plunk/dashboard build",
-		"build:shared": "yarn generate && yarn workspace @plunk/shared build",
-		"clean": "rimraf node_modules yarn.lock && yarn add lerna -DW && lerna run clean",
-		"preinstall": "node tools/preinstall.js",
-		"migrate": "prisma migrate dev",
-		"migrate:deploy": "prisma migrate deploy",
-		"generate": "prisma generate",
-		"services:up": "docker compose -f docker-compose.dev.yml up -d",
-		"services:down": "docker compose -f docker-compose.dev.yml down"
-	}
+  "name": "plunk",
+  "version": "1.0.3",
+  "private": true,
+  "license": "agpl-3.0",
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  },
+  "engines": {
+    "npm": ">=6.14.x",
+    "yarn": "1.22.x",
+    "node": ">=18.x"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.8.3",
+    "lerna": "^8.1.6",
+    "prisma": "^5.17.0",
+    "rimraf": "^5.0.9"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.17.0"
+  },
+  "scripts": {
+    "dev:api": "yarn workspace @plunk/api dev",
+    "dev:dashboard": "yarn workspace @plunk/dashboard dev",
+    "dev:shared": "yarn workspace @plunk/shared dev",
+    "build:api": "yarn build:shared && yarn workspace @plunk/api build",
+    "build:dashboard": "yarn build:shared && yarn workspace @plunk/dashboard build",
+    "build:shared": "yarn generate && yarn workspace @plunk/shared build",
+    "clean": "rimraf node_modules yarn.lock && yarn add lerna -DW && lerna run clean",
+    "preinstall": "node tools/preinstall.js",
+    "migrate": "prisma migrate dev",
+    "migrate:deploy": "prisma migrate deploy",
+    "generate": "prisma generate",
+    "services:up": "docker compose -f docker-compose.dev.yml up -d",
+    "services:down": "docker compose -f docker-compose.dev.yml down"
+  }
 }

--- a/packages/api/src/app/constants.ts
+++ b/packages/api/src/app/constants.ts
@@ -27,6 +27,14 @@ export const DISABLE_SIGNUPS = validateEnv("DISABLE_SIGNUPS", "false").toLowerCa
 export const API_URI = validateEnv("API_URI", "http://localhost:4000");
 export const APP_URI = validateEnv("APP_URI", "http://localhost:3000");
 
+if (!API_URI.startsWith("http")) {
+	throw new Error("API_URI must start with 'http'");
+}
+
+if (!APP_URI.startsWith("http")) {
+	throw new Error("APP_URI must start with 'http'");
+}
+
 // AWS
 export const AWS_REGION = validateEnv("AWS_REGION");
 export const AWS_ACCESS_KEY_ID = validateEnv("AWS_ACCESS_KEY_ID");

--- a/packages/api/src/database/prisma.ts
+++ b/packages/api/src/database/prisma.ts
@@ -1,3 +1,11 @@
 import {PrismaClient} from '@prisma/client';
+import signale from 'signale';
 
-export const prisma = new PrismaClient();
+let prisma: PrismaClient;
+try {
+  prisma = new PrismaClient();
+  signale.info('Prisma initialized');
+} catch (error) {
+  signale.error('Failed to initialize Prisma: ', error);
+}
+export {prisma};

--- a/packages/api/src/services/redis.ts
+++ b/packages/api/src/services/redis.ts
@@ -1,7 +1,16 @@
 import Redis from 'ioredis';
 import {REDIS_URL} from '../app/constants';
+import signale from "signale";
 
-export const redis = new Redis(REDIS_URL);
+let redis: Redis;
+try {
+  redis = new Redis(REDIS_URL);
+  const infoString = redis.info();
+  signale.info('Redis initialized: ', infoString);
+} catch (error) {
+  signale.error('Failed to initialize Redis: ', error);
+}
+export {redis};
 
 export const REDIS_ONE_MINUTE = 60;
 export const REDIS_DEFAULT_EXPIRY = REDIS_ONE_MINUTE / 60;


### PR DESCRIPTION
In order to support TLS in Redis the url needs to start with `rediss://` and it was tripping me up. This should catch connection issues with Redis and Postgres and log them if they happen.