### PR TITLE
fix: refetch contact after awaiting triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "plunk",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"private": true,
 	"license": "agpl-3.0",
 	"workspaces": {

--- a/packages/api/src/controllers/v1/Contacts.ts
+++ b/packages/api/src/controllers/v1/Contacts.ts
@@ -103,13 +103,13 @@ export class Contacts {
 
 		const { id, email } = ContactSchemas.manage.parse(req.body);
 
-		const contact = id ? await ContactService.id(id) : await ContactService.email(project.id, email as string);
+		let contact = id ? await ContactService.id(id) : await ContactService.email(project.id, email as string);
 
 		if (!contact || contact.projectId !== project.id) {
 			throw new NotFound("contact");
 		}
 
-		await prisma.contact.update({
+		contact = await prisma.contact.update({
 			where: { id: contact.id },
 			data: { subscribed: false },
 		});
@@ -154,13 +154,13 @@ export class Contacts {
 
 		const { id, email } = ContactSchemas.manage.parse(req.body);
 
-		const contact = id ? await ContactService.id(id) : await ContactService.email(project.id, email as string);
+		let contact = id ? await ContactService.id(id) : await ContactService.email(project.id, email as string);
 
 		if (!contact || contact.projectId !== project.id) {
 			throw new NotFound("contact");
 		}
 
-		await prisma.contact.update({
+		contact = await prisma.contact.update({
 			where: { id: contact.id },
 			data: { subscribed: true },
 		});

--- a/packages/api/src/services/ActionService.ts
+++ b/packages/api/src/services/ActionService.ts
@@ -71,13 +71,6 @@ export class ActionService {
 
 		const triggers = await ContactService.triggers(contact.id);
 
-		// Refetch the contact, as it may have subscribed now
-		contact = await prisma.contact.findUniqueOrThrow({
-			where: {
-				id: contact.id,
-			},
-		});
-
 		for (const action of actions) {
 			const hasTriggeredAction = !!triggers.find((t) => t.actionId === action.id);
 

--- a/packages/api/src/services/ActionService.ts
+++ b/packages/api/src/services/ActionService.ts
@@ -71,6 +71,13 @@ export class ActionService {
 
 		const triggers = await ContactService.triggers(contact.id);
 
+		// Refetch the contact, as it may have subscribed now
+		contact = await prisma.contact.findUniqueOrThrow({
+			where: {
+				id: contact.id,
+			},
+		});
+
 		for (const action of actions) {
 			const hasTriggeredAction = !!triggers.find((t) => t.actionId === action.id);
 


### PR DESCRIPTION
This refetches the contact after triggers ran, so that marketing templates can be sent on actions triggered by the `subscribe` event. Otherwise the subscribe flag might still be false, because the contact has just subscribed and the entity is in a stale state and thus the template is not sent.
