### PR TITLE
Replace NEXT_PUBLIC_API_URI instead of API_URI

### DIFF
--- a/deployment/replace-variables.sh
+++ b/deployment/replace-variables.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
 echo "Baking Environment Variables..."
 
-if [ -z "${API_URI}" ]; then
-    echo "API_URI is not set. Exiting..."
+if [ -z "${NEXT_PUBLIC_API_URI}" ]; then
+    echo "NEXT_PUBLIC_API_URI is not set. Exiting..."
     exit 1
 fi
 
-if [ -z "${AWS_REGION}" ]; then
-    echo "AWS_REGION is not set. Exiting..."
+if [ -z "${NEXT_PUBLIC_AWS_REGION}" ]; then
+    echo "NEXT_PUBLIC_AWS_REGION is not set. Exiting..."
     exit 1
 fi
 
@@ -19,8 +20,8 @@ for dir in "/app/packages/dashboard/public" "/app/packages/dashboard/.next"; do
         find "$dir" -type f -name "*.js" -o -name "*.mjs" | while read -r file; do
             if [ -f "$file" ]; then
                 # Replace environment variables
-                sed -i "s|PLUNK_API_URI|${API_URI}|g" "$file"
-                sed -i "s|PLUNK_AWS_REGION|${AWS_REGION}|g" "$file"
+                sed -i "s|PLUNK_API_URI|${NEXT_PUBLIC_API_URI}|g" "$file"
+                sed -i "s|PLUNK_AWS_REGION|${NEXT_PUBLIC_AWS_REGION}|g" "$file"
                 echo "Processed: $file"
             fi
         done


### PR DESCRIPTION
`PLUNK_API_URI` is a placeholder for `NEXT_PUBLIC_API_URI` inside the Dockerfile.

https://github.com/useplunk/plunk/blob/f39ff2a9886a796293f1a3fc0c386694af5015ce/Dockerfile#L8

`API_URI` variable could be an internal URI like `http://plunk:3000` while `NEXT_PUBLIC_API_URI` has to be public.

Separating internal and public URI variables can help with performance by avoiding network overhead for server requests.

This commit also solves the issue #114 by using an internal URI for `API_URI`.