### PR TITLE
Add basic health check api route

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -22,6 +22,7 @@ import { Webhooks } from "./controllers/Webhooks";
 import { V1 } from "./controllers/v1";
 import { prisma } from "./database/prisma";
 import { HttpException } from "./exceptions";
+import { Health } from "./controllers/Health";
 
 const server = new (class extends Server {
 	public constructor() {
@@ -69,6 +70,7 @@ const server = new (class extends Server {
 			new Identities(),
 			new Tasks(),
 			new V1(),
+			new Health(),
 		]);
 
 		this.app.use("*", () => {

--- a/packages/api/src/controllers/Health.ts
+++ b/packages/api/src/controllers/Health.ts
@@ -1,0 +1,10 @@
+import { Controller, Get } from "@overnightjs/core";
+import type { Request, Response } from "express";
+
+@Controller("health")
+export class Health {
+	@Get("")
+	public async health(req: Request, res: Response) {
+		return res.json({ success: true });
+	}
+}

--- a/packages/dashboard/src/pages/api/health.ts
+++ b/packages/dashboard/src/pages/api/health.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+import { network } from './../../lib/network'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new Error('Timeout'));
+      }, 2000);
+    });
+
+    const healthPromise = network.fetch("GET", "/health");
+
+    await Promise.race([healthPromise, timeoutPromise]);
+
+    return res.status(200).json({ message: 'OK' });
+  } catch (error) {
+    return res.status(500).json({ message: 'Internal Server Error' });
+  }
+}


### PR DESCRIPTION
Hi!

I added a basic health check API route, both to the actual API and to the Next.js app. The Next.js apps health check just passes along the result of the API health check. The passthrough is done so that you can only expose the frontend, but still get healthchecks from the API to workaround this issue: #114 

The timeout of 2 seconds is arbitrary. Not sure if it makes sense to make that configurable.

Cheers,
Jonas