### PR TITLE
OpenSSL problem with new Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY . .
 
 ARG NEXT_PUBLIC_API_URI=PLUNK_API_URI
 
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 RUN yarn install --network-timeout 1000000
 RUN yarn build:shared
 RUN yarn workspace @plunk/api build
@@ -17,6 +18,7 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
 RUN apk add --no-cache bash nginx
 
 COPY --from=base /app/packages/api/dist /app/packages/api/


### PR DESCRIPTION
In the latest version of node they move OpenSSL to a different folder and here is more about it: https://github.com/nodejs/docker-node/issues/2175#issuecomment-2530130523

This pull request fixed that, I believe that Prisma, which has a problem with it will soon also fix that issue and these two lines won't be needed anymore.

