### PR TITLE
Remove 'subscribed' property from contact creation request

### DIFF
--- a/packages/dashboard/src/pages/contacts/index.tsx
+++ b/packages/dashboard/src/pages/contacts/index.tsx
@@ -97,7 +97,6 @@ export default function Index() {
 		toast.promise(
 			network.mock<Template, typeof ContactSchemas.create>(project.secret, "POST", "/v1/contacts", {
 				...data,
-				subscribed: true,
 				data: dataObject,
 			}),
 			{


### PR DESCRIPTION
The `subscribed` value should be read from form data.