### PR TITLE
Optimize of Activity feed and Contact search query

### DIFF
--- a/packages/api/src/controllers/Projects.ts
+++ b/packages/api/src/controllers/Projects.ts
@@ -187,7 +187,7 @@ export class Projects {
 
 		const { query } = z.object({ query: z.string().min(1) }).parse(req.query);
 		const queryLike = `%${query}%`;
-		const contacts = await prisma.$queryRaw`
+		const contacts = await prisma.$queryRaw<any[]>`
 			SELECT
 				c."id",
 				c."email",

--- a/packages/api/src/services/ProjectService.ts
+++ b/packages/api/src/services/ProjectService.ts
@@ -145,7 +145,7 @@ export class ProjectService {
 		const itemsPerPage = 10;
 		const skip = (page - 1) * itemsPerPage;
 
-		const results = await prisma.$queryRaw`
+		const results = await prisma.$queryRaw<{ body: string }[]>`
 			(
 				SELECT
 					to_jsonb (t) || jsonb_build_object (
@@ -176,7 +176,7 @@ export class ProjectService {
 				"createdAt" DESC
 			OFFSET ${skip} LIMIT ${itemsPerPage};
 		`
-		return results.map(row => row.body);
+		return results.map((row: { body: string }) => row.body);
 	}
 
 	public static usage(id: string) {

--- a/packages/dashboard/src/lib/hooks/contacts.ts
+++ b/packages/dashboard/src/lib/hooks/contacts.ts
@@ -85,19 +85,13 @@ export function searchContacts(query: string | undefined) {
 
   if (!query) {
     return useSWR<{
-      contacts: (Contact & {
-        triggers: Trigger[];
-        emails: Email[];
-      })[];
+      contacts: Contact[];
       count: number;
     }>(activeProject ? `/projects/id/${activeProject.id}/contacts` : null);
   }
 
   return useSWR<{
-    contacts: (Contact & {
-      triggers: Trigger[];
-      emails: Email[];
-    })[];
+    contacts: Contact[];
     count: number;
   }>(activeProject ? `/projects/id/${activeProject.id}/contacts/search?query=${query}` : null, {
     revalidateOnFocus: false,

--- a/packages/dashboard/src/pages/contacts/index.tsx
+++ b/packages/dashboard/src/pages/contacts/index.tsx
@@ -140,24 +140,11 @@ export default function Index() {
                                         <>
                                                 <Table
                                                         values={filtered
-                                                                .sort((a, b) => {
-                                                                        const aTrigger = a.triggers.length > 0 ? a.triggers.sort()[0].createdAt : a.createdAt;
-
-                                                                        const bTrigger = b.triggers.length > 0 ? b.triggers.sort()[0].createdAt : b.createdAt;
-
-                                                                        return bTrigger > aTrigger ? 1 : -1;
-                                                                })
                                                                 .map((u) => {
                                                                         return {
                                                                                 Email: u.email,
                                                                                 "Last Activity": dayjs()
-                                                                                        .to(
-                                                                                                [...u.triggers, ...u.emails].length > 0
-                                                                                                        ? [...u.triggers, ...u.emails].sort((a, b) => {
-                                                                                                                return a.createdAt > b.createdAt ? -1 : 1;
-                                                                                                        })[0].createdAt
-                                                                                                        : u.createdAt,
-                                                                                        )
+                                                                                        .to(u.createdAt)
                                                                                         .toString(),
                                                                                 Subscribed: u.subscribed,
                                                                                 Edit: (
@@ -238,7 +225,7 @@ export default function Index() {
                                                         <div className="hidden sm:block">
                                                                 <p className="text-sm text-neutral-700">
                                                                         Showing <span className="font-medium">{(page - 1) * 20}</span> to{" "}
-                                                                        <span className="font-medium">{page * 20}</span> of <span className="font-medium">{filtered.length}</span>{" "}
+                                                                        <span className="font-medium">{page * 20}</span> of <span className="font-medium">{contacts.count}</span>{" "}
                                                                         contacts
                                                                 </p>
                                                         </div>


### PR DESCRIPTION
On Contact search, we get rid of additional queries for triggers and emails, and is now done with joins. Also, we return already greatest createdAt and sort by it on the query level.

For Avtivity Feed, we do limits and offset already on the DB level, that way queries become way faster because they don't need to get all the data from the DB to the backend. To get the same format, we used to_jsonb and jsonb_build_object. For bringing triggers and emails to the same table we used UNION, for that reason, all can be done in the DB level, even pagination.

Extra small fix is `filtered.length` to `contacts.count`, where I think that the correct value that should be used.