### PR TITLE
fix: server crash in self-hosted instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "plunk",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"private": true,
 	"license": "agpl-3.0",
 	"workspaces": {

--- a/packages/api/src/app/cron.ts
+++ b/packages/api/src/app/cron.ts
@@ -1,13 +1,13 @@
 import cron from "node-cron";
 import signale from "signale";
-import { API_URI } from "./constants";
 
-export const task = cron.schedule("* * * * *", () => {
+import { Identities } from "../controllers/Identities";
+import { Tasks } from "../controllers/Tasks";
+
+export const task = cron.schedule("* * * * *", async () => {
 	signale.info("Running scheduled tasks");
 	try {
-		void fetch(`${API_URI}/tasks`, {
-			method: "POST",
-		});
+		await (new Tasks().handleTasks());
 	} catch (e) {
 		signale.error("Failed to run scheduled tasks. Please check the error below");
 		console.error(e);
@@ -15,9 +15,7 @@ export const task = cron.schedule("* * * * *", () => {
 
 	signale.info("Updating verified identities");
 	try {
-		void fetch(`${API_URI}/identities/update`, {
-			method: "POST",
-		});
+		await (new Identities().updateIdentities());
 	} catch (e) {
 		signale.error("Failed to update verified identities. Please check the error below");
 		console.error(e);

--- a/packages/api/src/controllers/Identities.ts
+++ b/packages/api/src/controllers/Identities.ts
@@ -99,7 +99,12 @@ export class Identities {
 	}
 
 	@Post("update")
-	public async updateIdentities(req: Request, res: Response) {
+	public async updateIdentitiesApi(req: Request, res: Response) {
+		await (new Identities().updateIdentities());
+		return res.status(200).json({ success: true });
+	}
+
+	public async updateIdentities() {
 		const count = await prisma.project.count({
 			where: { email: { not: null } },
 		});
@@ -155,8 +160,6 @@ export class Identities {
 					await redis.del(Keys.Project.public(project.public));
 				}
 			}
-		}
-
-		return res.status(200).json({ success: true });
+		}		
 	}
 }

--- a/packages/api/src/controllers/Tasks.ts
+++ b/packages/api/src/controllers/Tasks.ts
@@ -9,7 +9,12 @@ import { ProjectService } from "../services/ProjectService";
 @Controller("tasks")
 export class Tasks {
 	@Post()
-	public async handleTasks(req: Request, res: Response) {
+	public async handleTasksApi(req: Request, res: Response) {
+		await (new Tasks().handleTasks());
+		return res.status(200).json({ success: true });
+	}
+
+	public async handleTasks() {
 		// Get all tasks with a runBy data in the past
 		const tasks = await prisma.task.findMany({
 			where: { runBy: { lte: new Date() } },
@@ -128,7 +133,5 @@ export class Tasks {
 
 			signale.success(`Task completed for ${contact.email} from ${project.name}`);
 		}
-
-		return res.status(200).json({ success: true });
 	}
 }


### PR DESCRIPTION
We can directly call the class instance methods instead of calling the API in the cron, which leads to the server crashing every few days. Fixes #114 #195.