### PR TITLE
fix: enable deleting metadata (fixes #182)

### DIFF
--- a/packages/api/src/controllers/v1/index.ts
+++ b/packages/api/src/controllers/v1/index.ts
@@ -94,7 +94,11 @@ export class V1 {
 			givenUserData.forEach(([key, value]) => {
 				userData[key] = value.value;
 				if (value.persistent) {
-					dataToUpdate[key] = value.value;
+					if (!value.value) {
+						delete dataToUpdate[key];
+					} else {
+						dataToUpdate[key] = value.value;
+					}
 				}
 			});
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,13 +42,19 @@ export const UserSchemas = {
 	}),
 };
 
+const metadataError = "Metadata can only be null, a string, array of strings or a non-persistent object (https://docs.useplunk.com/working-with-contacts/metadata#non-persistent-metadata)";
+
 const zodSchema = z.record(
 	z.union(
 		[
+			z.null({
+				invalid_type_error: metadataError,
+			}).transform(() => {
+				return { persistent: true, value: null };
+			}),
 			z
 				.string({
-					invalid_type_error:
-						"Metadata can only be a string, array of strings or a non-persistent object (https://docs.useplunk.com/working-with-contacts/metadata#non-persistent-metadata)",
+					invalid_type_error: metadataError,
 				})
 				.transform((s) => {
 					return { persistent: true, value: s };
@@ -56,8 +62,7 @@ const zodSchema = z.record(
 			z
 				.array(
 					z.string({
-						invalid_type_error:
-							"Metadata can only be a string, array of strings or a non-persistent object (https://docs.useplunk.com/working-with-contacts/metadata#non-persistent-metadata)",
+						invalid_type_error: metadataError,
 					}),
 				)
 				.transform((s) => {
@@ -67,19 +72,16 @@ const zodSchema = z.record(
 				{
 					persistent: z.boolean({ invalid_type_error: "Persistent should be a boolean" }).optional().default(true),
 					value: z.union([z.string(), z.array(z.string())], {
-						invalid_type_error:
-							"Metadata can only be a string, array of strings or a non-persistent object (https://docs.useplunk.com/working-with-contacts/metadata#non-persistent-metadata)",
+							invalid_type_error: metadataError,
 					}),
 				},
 				{
-					invalid_type_error:
-						"Metadata can only be a string, array of strings or a non-persistent object (https://docs.useplunk.com/working-with-contacts/metadata#non-persistent-metadata)",
+					invalid_type_error: metadataError,
 				},
 			),
 		],
 		{
-			invalid_type_error:
-				"Metadata can only be a string, array of strings or a non-persistent object (https://docs.useplunk.com/working-with-contacts/metadata#non-persistent-metadata)",
+			invalid_type_error: metadataError,
 		},
 	),
 	{ invalid_type_error: "Metadata should be an object (https://docs.useplunk.com/working-with-contacts/metadata)" },


### PR DESCRIPTION
This PR fixes #182 and also fixes the same issue on the /v1/track endpoint.

 - Updated the track controller to have the same delete on falsy logic as the contact endpoint
 - Updated the zod schema to enable passing null values to the track controller
 - Added logic in the contact update screen to set any key that is on the existing contact that's not on the update to null so that the key will be deleted
 - Moved the full-screen loader down below the hooks to avoid hook mismatch errors in React