### PR TITLE
feat: add support for customizing the base template

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
 		"migrate:deploy": "prisma migrate deploy",
 		"generate": "prisma generate",
 		"services:up": "docker compose -f docker-compose.dev.yml up -d",
-		"services:down": "docker compose -f docker-compose.dev.yml down"
+		"services:down": "docker compose -f docker-compose.dev.yml down",
+		"ses-local": "yarn dlx aws-ses-v2-local"
 	},
 	"packageManager": "yarn@4.3.0"
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,6 +40,7 @@
 		"dotenv": "^16.4.5",
 		"express": "^4.19.2",
 		"express-async-errors": "^3.1.1",
+		"handlebars": "^4.7.8",
 		"helmet": "^7.1.0",
 		"ioredis": "^5.4.1",
 		"jsonwebtoken": "^9.0.2",

--- a/packages/api/src/controllers/Tasks.ts
+++ b/packages/api/src/controllers/Tasks.ts
@@ -5,6 +5,7 @@ import { prisma } from "../database/prisma";
 import { ContactService } from "../services/ContactService";
 import { EmailService } from "../services/EmailService";
 import { ProjectService } from "../services/ProjectService";
+import { TemplatingLanguage } from "@plunk/shared";
 
 @Controller("tasks")
 export class Tasks {
@@ -66,6 +67,7 @@ export class Tasks {
 						plunk_email: contact.email,
 						...JSON.parse(contact.data ?? "{}"),
 					},
+					templatingLanguage: project.templatingLanguage as TemplatingLanguage ?? "DEFAULT",
 				}));
 			} else if (campaign) {
 				email = project.verified && project.email ? campaign.email ?? project.email : "no-reply@useplunk.dev";
@@ -79,6 +81,7 @@ export class Tasks {
 						plunk_email: contact.email,
 						...JSON.parse(contact.data ?? "{}"),
 					},
+					templatingLanguage: project.templatingLanguage as TemplatingLanguage ?? "DEFAULT",
 				}));
 			}
 
@@ -100,6 +103,8 @@ export class Tasks {
 						},
 						project: {
 							name: project.name,
+							baseTemplate: project.baseTemplate,
+							unsubscribeFooter: project.unsubscribeFooter,
 						},
 						isHtml: (campaign && campaign.style === "HTML") ?? (!!action && action.template.style === "HTML"),
 					}),

--- a/packages/api/src/controllers/v1/Campaigns.ts
+++ b/packages/api/src/controllers/v1/Campaigns.ts
@@ -123,6 +123,8 @@ export class Campaigns {
 						},
 						project: {
 							name: project.name,
+							baseTemplate: project.baseTemplate,
+							unsubscribeFooter: project.unsubscribeFooter,
 						},
 					}),
 				},

--- a/packages/api/src/controllers/v1/index.ts
+++ b/packages/api/src/controllers/v1/index.ts
@@ -1,5 +1,5 @@
 import { ChildControllers, Controller, Middleware, Post } from "@overnightjs/core";
-import { EventSchemas } from "@plunk/shared";
+import { EventSchemas, TemplatingLanguage } from "@plunk/shared";
 import dayjs from "dayjs";
 import type { Request, Response } from "express";
 import signale from "signale";
@@ -200,6 +200,7 @@ export class V1 {
 					plunk_email: contact.email,
 					...JSON.parse(contact.data ?? "{}"),
 				},
+				templatingLanguage: project.templatingLanguage as TemplatingLanguage ?? "DEFAULT",
 			});
 
 			const { messageId } = await EmailService.send({
@@ -224,6 +225,8 @@ export class V1 {
 						},
 						project: {
 							name: project.name,
+							baseTemplate: project.baseTemplate,
+							unsubscribeFooter: project.unsubscribeFooter,
 						},
 					}),
 				},

--- a/packages/api/src/services/ActionService.ts
+++ b/packages/api/src/services/ActionService.ts
@@ -5,6 +5,7 @@ import { ContactService } from "./ContactService";
 import { EmailService } from "./EmailService";
 import { Keys } from "./keys";
 import { wrapRedis } from "./redis";
+import { TemplatingLanguage } from "shared/dist";
 
 export class ActionService {
 	/**
@@ -116,6 +117,7 @@ export class ActionService {
 						plunk_email: contact.email,
 						...JSON.parse(contact.data ?? "{}"),
 					},
+					templatingLanguage: project.templatingLanguage as TemplatingLanguage,
 				});
 
 				const { messageId } = await EmailService.send({
@@ -136,6 +138,8 @@ export class ActionService {
 							},
 							project: {
 								name: project.name,
+								baseTemplate: project.baseTemplate,
+								unsubscribeFooter: project.unsubscribeFooter,
 							},
 							isHtml: action.template.style === "HTML",
 						}),

--- a/packages/api/src/services/EmailService.ts
+++ b/packages/api/src/services/EmailService.ts
@@ -1,6 +1,8 @@
 import mjml2html from "mjml";
 import { APP_URI, AWS_SES_CONFIGURATION_SET } from "../app/constants";
 import { ses } from "../util/ses";
+import { DEFAULT_BASE_TEMPLATE, DEFAULT_FOOTER, TemplatingLanguage } from "@plunk/shared";
+import Handlebars from "handlebars";
 
 export class EmailService {
 	public static async send({
@@ -113,6 +115,8 @@ ${EmailService.breakLongLines(attachment.content, 76, true)}
 
 		project: {
 			name: string;
+			baseTemplate: string | null;
+			unsubscribeFooter: string | null;
 		};
 		contact: {
 			id: string;
@@ -124,397 +128,46 @@ ${EmailService.breakLongLines(attachment.content, 76, true)}
 	}) {
 		const html = content.replace(/<img/g, "<img");
 
-		if (isHtml) {
+		const unsubscribeLink = `${APP_URI.startsWith("https://") ? APP_URI : `https://${APP_URI}`}/unsubscribe/${contact.id}`;		
+
+		if(isHtml) {
+			let unsubscribeFooter: string = '';
+
+			if(footer.unsubscribe) {
+				const result = mjml2html((project.unsubscribeFooter ?? DEFAULT_FOOTER).replace("{{unsubscribe_url}}", unsubscribeLink).replace("{{project_name}}", project.name));
+				if(result.errors.length > 0) {
+					throw new Error(result.errors[0].message);
+				}
+				unsubscribeFooter = result.html.replace(/^\s+|\s+$/g, "");
+			}
 			return `${html}
 
-${
-	footer.unsubscribe
-		? ` <table align="center" width="100%" style="max-width: 480px; width: 100%; margin-left: auto; margin-right: auto; font-family: Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; border: 0; cellpadding: 0; cellspacing: 0;" role="presentation">
-      <tbody>
-        <tr>
-          <td>
-            <hr style="border: none; border-top: 1px solid #eaeaea; width: 100%; margin-top: 12px; margin-bottom: 12px;">
-            <p style="font-size: 12px; line-height: 24px; margin: 16px 0; text-align: center; color: rgb(64, 64, 64);">
-              You received this email because you agreed to receive emails from ${project.name}. If you no longer wish to receive emails like this, please 
-              <a href="${APP_URI.startsWith("https://") ? APP_URI : `https://${APP_URI}`}/unsubscribe/${contact.id}">update your preferences</a>.
-            </p>
-          </td>
-        </tr>
-      </tbody>
-    </table>`
-		: ""
-}`;
+${unsubscribeFooter}`;
 		}
-		return mjml2html(
-			`<mjml>
-  <mj-head>
-    <mj-font name="Inter" href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" />
-    <mj-style inline="inline">
-      .prose {
-        color: #4a5568;
-        max-width: 600px;
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-      }
 
-      .prose [class~="lead"] {
-        color: #4a5568;
-        font-size: 20px;
-        line-height: 32px;
-        margin-top: 19px;
-        margin-bottom: 19px;
-      }
+		let unsubscribeFooter: string = '';
 
-      .prose a {
-        color: #1a202c;
-        text-decoration: underline;
-      }
+		if(footer.unsubscribe) {
+			unsubscribeFooter = (project.unsubscribeFooter ?? DEFAULT_FOOTER).replace("{{unsubscribe_url}}", unsubscribeLink).replace("{{project_name}}", project.name);
+		}
 
-      .prose strong {
-        color: #1a202c;
-        font-weight: 600;
-      }
+    	const compiledTemplate = (project.baseTemplate ?? DEFAULT_BASE_TEMPLATE).replace("{{html}}", html).replace("{{unsubscribe_footer}}", unsubscribeFooter);
 
-      .prose ol {
-        counter-reset: list-counter;
-        margin-top: 20px;
-        margin-bottom: 20px;
-      }
-
-      .prose ol > li {
-        position: relative;
-        counter-increment: list-counter;
-        padding-left: 28px;
-      }
-
-      .prose ol > li::before {
-        content: counter(list-counter) ".";
-        position: absolute;
-        font-weight: 400;
-        color: #718096;
-      }
-
-      .prose ul > li {
-        position: relative;
-        padding-left: 28px;
-      }
-
-      .prose ul > li::before {
-        content: "";
-        position: absolute;
-        background-color: #cbd5e0;
-        border-radius: 50%;
-        width: 6px;
-        height: 6px;
-        top: 11px;
-        left: 4px;
-      }
-
-      .prose hr {
-        border-color: #e2e8f0;
-        border-top-width: 1px;
-        margin-top: 42px;
-        margin-bottom: 42px;
-      }
-
-      .prose blockquote {
-        font-weight: 500;
-        font-style: italic;
-        color: #1a202c;
-        border-left: 4px solid #e2e8f0;
-        quotes: initial;
-        margin-top: 25px;
-        margin-bottom: 25px;
-        padding-left: 16px;
-      }
-
-      .prose h1 {
-        color: #1a202c;
-        font-weight: 800;
-        font-size: 36px;
-        margin-top: 0px;
-        margin-bottom: 14px;
-        line-height: 40px;
-      }
-
-      .prose h2 {
-        color: #1a202c;
-        font-weight: 700;
-        font-size: 24px;
-        margin-top: 32px;
-        margin-bottom: 16px;
-        line-height: 32px;
-      }
-
-      .prose h3 {
-        color: #1a202c;
-        font-weight: 600;
-        font-size: 20px;
-        margin-top: 25px;
-        margin-bottom: 9.6px;
-        line-height: 32px;
-      }
-
-      .prose h4 {
-        color: #1a202c;
-        font-weight: 600;
-        margin-top: 24px;
-        margin-bottom: 8px;
-        line-height: 1.5;
-      }
-
-      .prose figure figcaption {
-        color: #718096;
-        font-size: 14px;
-        line-height: 1.4;
-        margin-top: 14px;
-      }
-
-      .prose code {
-        color: #1a202c;
-        font-weight: 600;
-        font-size: 14px;
-      }
-
-      .prose code::before {
-        content: "\`";
-      }
-
-      .prose code::after {
-        content: "\`";
-      }
-
-      .prose pre {
-        color: #e2e8f0;
-        background-color: #2d3748;
-        overflow-x: auto;
-        font-size: 14px;
-        line-height: 1.7142857;
-        margin-top: 27px;
-        margin-bottom: 27px;
-        border-radius: 6px;
-        padding-top: 13px;
-        padding-right: 18px;
-        padding-bottom: 13px;
-        padding-left: 18px;
-      }
-
-      .prose pre code {
-        background-color: transparent;
-        border-width: 0;
-        border-radius: 0;
-        padding: 0;
-        font-weight: 400;
-        color: inherit;
-        font-size: inherit;
-        font-family: inherit;
-        line-height: inherit;
-      }
-
-      .prose pre code::before {
-        content: "";
-      }
-
-      .prose pre code::after {
-        content: "";
-      }
-
-      .prose table {
-        width: 100%;
-        table-layout: auto;
-        margin-top: 32px;
-        margin-bottom: 32px;
-        font-size: 11px;
-        line-height: 1.7142857;
-      }
-
-      .prose thead {
-        color: #1a202c;
-        font-weight: 600;
-        border-bottom: 1px solid #cbd5e0;
-      }
-
-      .prose thead th {
-        vertical-align: bottom;
-        padding-right: 9px;
-        padding-bottom: 9px;
-        padding-left: 9px;
-      }
-
-      .prose tbody tr {
-        border-bottom: 1px solid #e2e8f0;
-      }
-
-      .prose tbody tr:last-child {
-        border-bottom-width: 0;
-      }
-
-      .prose tbody td {
-        vertical-align: top;
-        padding-top: 9px;
-        padding-right: 9px;
-        padding-bottom: 9px;
-        padding-left: 9px;
-      }
-
-      .prose {
-        font-size: 16px;
-        line-height: 1.75;
-      }
-
-      .prose p {
-        margin-top: 20px;
-        margin-bottom: 20px;
-      }
-
-      .prose img {
-        margin-top: 32px;
-        margin-bottom: 32px;
-        max-width: 100%;
-        height: auto;
-        display: block;
-      }
-
-      .prose video {
-        margin-top: 32px;
-        margin-bottom: 32px;
-      }
-
-      .prose figure {
-        margin-top: 32px;
-        margin-bottom: 32px;
-      }
-
-      .prose figure > * {
-        margin-top: 0;
-        margin-bottom: 0;
-      }
-
-      .prose h2 code {
-        font-size: 14px;
-      }
-
-      .prose h3 code {
-        font-size: 14px;
-      }
-
-      .prose ul {
-        margin-top: 20px;
-        margin-bottom: 20px;
-      }
-
-      .prose li {
-        margin-top: 8px;
-        margin-bottom: 8px;
-      }
-
-      .prose ol > li:before {
-        left: 0;
-      }
-
-      .prose > ul > li p {
-        margin-top: 12px;
-        margin-bottom: 12px;
-      }
-
-      .prose > ul > li > *:first-child {
-        margin-top: 20px;
-      }
-
-      .prose > ul > li > *:last-child {
-        margin-bottom: 20px;
-      }
-
-      .prose > ol > li > *:first-child {
-        margin-top: 20px;
-      }
-
-      .prose > ol > li > *:last-child {
-        margin-bottom: 20px;
-      }
-
-      .prose ul ul,
-      .prose ul ol,
-      .prose ol ul,
-      .prose ol ol {
-        margin-top: 12px;
-        margin-bottom: 12px;
-      }
-
-      .prose hr + * {
-        margin-top: 0;
-      }
-
-      .prose h2 + * {
-        margin-top: 0;
-      }
-
-      .prose h3 + * {
-        margin-top: 0;
-      }
-
-      .prose h4 + * {
-        margin-top: 0;
-      }
-
-      .prose thead th:first-child {
-        padding-left: 0;
-      }
-
-      .prose thead th:last-child {
-        padding-right: 0;
-      }
-
-      .prose tbody td:first-child {
-        padding-left: 0;
-      }
-
-      .prose tbody td:last-child {
-        padding-right: 0;
-      }
-
-      .prose > :first-child {
-        margin-top: 0;
-      }
-
-      .prose > :last-child {
-        margin-bottom: 0;
-      }
-    </mj-style>
-  </mj-head>
-  <mj-body>
-    <mj-section>
-      <mj-column>
-        <mj-raw>
-          <tr class="prose prose-neutral">
-            <td style="padding:10px 25px;word-break:break-word">
-              ${html}
-            </td>
-          </tr>
-        </mj-raw>
-      </mj-column>
-    </mj-section>
-     <mj-section>
-      <mj-column>
-        ${
-									footer.unsubscribe
-										? `
-              <mj-divider border-width="2px" border-color="#f5f5f5"></mj-divider>
-              <mj-text align="center">
-                <p style="color: #a3a3a3; text-decoration: none; font-size: 12px; line-height: 1.7142857;">
-                  You received this email because you agreed to receive emails from ${project.name}. If you no longer wish to receive emails like this, please <a style="text-decoration: underline" href="${APP_URI.startsWith("https://") ? APP_URI : `https://${APP_URI}`}/unsubscribe/${contact.id}" target="_blank">update your preferences</a>.
-                </p>
-              </mj-text>
-            `
-										: ""
-								}
-      </mj-column>
-    </mj-section>
-  </mj-body>
-</mjml>`,
-		).html.replace(/^\s+|\s+$/g, "");
+		const result = mjml2html(compiledTemplate);
+		if(result.errors.length > 0) {
+			throw new Error(result.errors[0].message);
+		}
+    	return result.html.replace(/^\s+|\s+$/g, "");
 	}
 
-	public static format({ subject, body, data }: { subject: string; body: string; data: Record<string, string> }) {
+	public static format({ templatingLanguage, subject, body, data }: { templatingLanguage: TemplatingLanguage; subject: string; body: string; data: { plunk_id: string, plunk_email: string} & Record<string, string> }) {
+		if (templatingLanguage === "HANDLEBARS") {
+			Handlebars.registerHelper("default", (expected, defaultValue) => expected ?? defaultValue);
+			return {
+				subject: Handlebars.compile(subject)(data),
+				body: Handlebars.compile(body)(data),
+			};
+		}
 		return {
 			subject: subject.replace(/\{\{(.*?)}}/g, (match, key) => {
 				const [mainKey, defaultValue] = key.split("??").map((s: string) => s.trim());

--- a/packages/dashboard/src/components/Navigation/SettingTabs/SettingTabs.tsx
+++ b/packages/dashboard/src/components/Navigation/SettingTabs/SettingTabs.tsx
@@ -10,6 +10,7 @@ export default function SettingTabs() {
 
   const links = [
     {to: '/settings/project', text: 'Project Settings', active: router.route === '/settings/project'},
+    {to: '/settings/base-template', text: 'Base Template', active: router.route === '/settings/base-template'},
     {to: '/settings/api', text: 'API Keys', active: router.route === '/settings/api'},
     {to: '/settings/identity', text: 'Verified Domain', active: router.route === '/settings/identity'},
     {to: '/settings/members', text: 'Members', active: router.route === '/settings/members'},

--- a/packages/dashboard/src/pages/settings/base-template.tsx
+++ b/packages/dashboard/src/pages/settings/base-template.tsx
@@ -1,0 +1,253 @@
+import type { Project } from "@prisma/client";
+import React, { useCallback, useEffect, useState } from "react";
+import { DEFAULT_BASE_TEMPLATE, DEFAULT_FOOTER, ProjectSchemas, TemplatingLanguage } from "@plunk/shared";
+import { Card, Dropdown, FullscreenLoader, SettingTabs } from "../../components";
+import { Dashboard } from "../../layouts";
+import { useActiveProject, useProjects } from "../../lib/hooks/projects";
+import { network } from "../../lib/network";
+import HTMLEditor from "@monaco-editor/react";
+
+import { toast } from "sonner";
+import { motion } from "framer-motion";
+
+/**
+ *
+ */
+export default function Index() {
+	const [project, setProject] = useState<Project>();
+	const { data: projects, mutate: projectsMutate } = useProjects();
+	const activeProject = useActiveProject();
+	const [baseTemplate, setBaseTemplate] = useState<string | undefined>();
+	const [unsubscribeFooter, setUnsubscribeFooter] = useState<string | undefined>();
+	const [preview, setPreview] = useState<string | undefined>(undefined);
+	const [templatingLanguage, setTemplatingLanguage] = useState<TemplatingLanguage>("DEFAULT");
+	useEffect(() => {
+		if (activeProject) {
+			setBaseTemplate(activeProject.baseTemplate ?? undefined);
+			setUnsubscribeFooter(activeProject.unsubscribeFooter ?? undefined);
+			setTemplatingLanguage(activeProject.templatingLanguage as TemplatingLanguage ?? "DEFAULT");
+		}
+	}, [activeProject]);
+
+	useEffect(() => {
+		setPreview(undefined);
+	}, [baseTemplate, unsubscribeFooter]);
+
+	const validate = useCallback(() => {
+		let valid = true;
+		if (baseTemplate) {
+			['{{html}}', '{{unsubscribe_footer}}'].forEach((placeholder) => {
+				if (!baseTemplate.includes(placeholder)) {
+					toast.error(`The base template must contain the ${placeholder} placeholder`);
+					valid = false;
+				}
+			});
+		}
+		if (unsubscribeFooter) {
+			['{{unsubscribe_url}}', '{{project_name}}'].forEach((placeholder) => {
+				if (!unsubscribeFooter.includes(placeholder)) {
+					toast.error(`The unsubscribe footer must contain the ${placeholder} placeholder`);
+					valid = false;
+				}
+			});
+		}
+
+		return valid;
+	}, [baseTemplate, unsubscribeFooter]);
+
+	const update = useCallback(async () => {
+		if (!activeProject) {
+			return;
+		}
+
+		const valid = validate();
+
+		if (!valid) {
+			return;
+		}
+
+		toast.promise(
+			network.fetch<
+				{
+					success: true;
+				},
+				typeof ProjectSchemas.update
+			>("PUT", "/projects/update/", {
+				id: activeProject.id,
+				name: activeProject.name,
+				url: activeProject.url,
+				templatingLanguage,
+				baseTemplate,
+				unsubscribeFooter,
+			}),
+			{
+				loading: "Updating your project",
+				success: "Updated your project",
+				error: "Could not update your project",
+			},
+		);
+
+		await projectsMutate();
+	}, [activeProject, projectsMutate, baseTemplate, unsubscribeFooter, templatingLanguage]);
+
+
+	const previewTemplate = useCallback(async () => {
+		if (!activeProject) {
+			return;
+		}
+
+		const valid = validate();
+
+		if (!valid) {
+			return;
+		}
+
+		toast.promise(
+			async () => {
+				const body = await network.fetch<
+					{
+						success: true;
+						html: string;
+					},
+					typeof ProjectSchemas.update
+				>("POST", "/projects/preview/template", {
+					id: activeProject.id,
+					name: activeProject.name,
+					url: activeProject.url,
+					baseTemplate,
+					unsubscribeFooter,
+					templatingLanguage,
+				});
+				setPreview(body.html);
+			},
+			{
+				loading: "Loading template preview",
+				success: "Template preview loaded",
+				error: (data) => `Template preview failed: ${data.message}`,
+			},
+		)
+
+	}, [activeProject, baseTemplate, unsubscribeFooter, templatingLanguage]);
+
+	if (activeProject && !project) {
+		setProject(activeProject);
+	}
+
+	if (!project || !projects) {
+		return <FullscreenLoader />;
+	}
+
+	if (!activeProject) {
+		return <FullscreenLoader />;
+	}
+
+	return (
+		<>
+			<Dashboard>
+				<SettingTabs />
+				<Card
+					title={"Base Email Template"}
+					description={`Manage the base email template for ${activeProject.name}`}
+				>
+					<div className={"mb-3 sm:grid sm:gap-3 md:grid-cols-4"}>
+						<div className="sm:col-span-1">
+							<label className="block text-sm font-medium text-neutral-700">Templating Language</label>
+							<Dropdown
+								values={[
+									{ name: "Default", value: "DEFAULT" },
+									{ name: "Handlebars", value: "HANDLEBARS" },
+								] as const}
+								selectedValue={templatingLanguage}
+								onChange={(t) => setTemplatingLanguage(t as TemplatingLanguage)}
+							/>
+						</div>
+						<div className="sm:col-span-4">
+							<label className="block text-sm font-medium text-neutral-700">Email Template</label>
+							<div className="mt-1 h-full">
+								<HTMLEditor
+									height={400}
+									className={"rounded border border-neutral-300"}
+									language="html"
+									theme="vs-light"
+									value={baseTemplate ?? DEFAULT_BASE_TEMPLATE}
+									onChange={(e) => setBaseTemplate(e as string)}
+									options={{
+										inlineSuggest: true,
+										fontSize: "12px",
+										formatOnType: true,
+										autoClosingBrackets: true,
+										minimap: {
+											enabled: false,
+										},
+									}}
+								/>
+							</div>
+						</div>
+						<div className="sm:col-span-4">
+							<label className="block text-sm font-medium text-neutral-700">Unsubscribe Footer</label>
+							<div className="mt-1 h-full">
+								<HTMLEditor
+									height={200}
+									className={"rounded border border-neutral-300"}
+									language="html"
+									theme="vs-light"
+									value={unsubscribeFooter ?? DEFAULT_FOOTER}
+									onChange={(e) => setUnsubscribeFooter(e as string)}
+									options={{
+										inlineSuggest: true,
+										fontSize: "12px",
+										formatOnType: true,
+										autoClosingBrackets: true,
+										minimap: {
+											enabled: false,
+										},
+									}}
+								/>
+							</div>
+						</div>
+					</div>
+					<div className="mt-3 ml-auto flex gap-x-3 justify-end sm:col-span-4">
+						<button
+							className={
+								"block rounded border border-neutral-200 px-5 py-2.5 text-sm font-medium text-neutral-800 transition ease-in-out hover:bg-neutral-50"
+							}
+							onClick={() => previewTemplate()}
+						>
+							Preview
+						</button>
+						<button
+							className={
+								"block rounded border border-neutral-200 px-5 py-2.5 text-sm font-medium text-neutral-800 transition ease-in-out hover:bg-neutral-50"
+							}
+							onClick={() => {
+								setBaseTemplate(undefined);
+								setUnsubscribeFooter(undefined);
+								setTemplatingLanguage("DEFAULT");
+								toast.success("Reset to default");
+							}}
+						>
+							Reset to default
+						</button>
+						<motion.button
+							whileHover={{ scale: 1.05 }}
+							whileTap={{ scale: 0.9 }}
+							onClick={() => update()}
+							className={
+								"flex items-center rounded bg-neutral-800 px-5 py-2.5 text-center text-sm font-medium text-white"
+							}
+						>
+							Save
+						</motion.button>
+
+					</div>
+				</Card>
+				{preview && (
+					<Card title={"Preview"} >
+						<div className="mt-3">
+							<iframe srcDoc={preview} className="w-full min-h-[400px] rounded border border-neutral-300" />
+						</div>
+					</Card>)}
+			</Dashboard>
+		</>
+	);
+}

--- a/packages/dashboard/src/pages/settings/project.tsx
+++ b/packages/dashboard/src/pages/settings/project.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ProjectSchemas, type UtilitySchemas } from "@plunk/shared";
+import { ProjectSchemas, TemplatingLanguage, type UtilitySchemas } from "@plunk/shared";
 import { network } from "dashboard/src/lib/network";
 import { motion } from "framer-motion";
 import { useRouter } from "next/router";
@@ -58,6 +58,9 @@ export default function Index() {
 				typeof ProjectSchemas.update
 			>("PUT", "/projects/update/", {
 				id: activeProject.id,
+				baseTemplate: activeProject.baseTemplate,
+				unsubscribeFooter: activeProject.unsubscribeFooter,
+				templatingLanguage: activeProject.templatingLanguage as TemplatingLanguage ?? "DEFAULT",
 				...data,
 			}),
 			{

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,8 @@
 import { TemplateStyle, TemplateType } from "@prisma/client";
 import { z } from "zod";
 
+export * from "./templates";
+
 const email = z
 	.string({ invalid_type_error: "Email needs to be a string", required_error: "Email is required" })
 	.email({ message: "Invalid email address" })
@@ -245,17 +247,22 @@ export const MembershipSchemas = {
 	}),
 };
 
+const templatingLanguage = z.enum(["DEFAULT", "HANDLEBARS"]);
+
+export type TemplatingLanguage = z.infer<typeof templatingLanguage>;
+
+
 export const ProjectSchemas = {
 	secret: z.object({
 		secret: z.string(),
 	}),
 	create: z.object({
 		name: z.string().min(1, "Name can't be empty"),
-
 		url: z
 			.string()
 			.regex(/^(?:(?:https?):\/\/)?(?:[\w-]+\.)+[a-z]{2,}(?:\/[^\s]*)?$/)
 			.transform((u) => (u.startsWith("http") ? u : `https://${u}`)),
+		templatingLanguage: templatingLanguage.default("DEFAULT"),
 	}),
 	update: z.object({
 		id: id,
@@ -265,6 +272,9 @@ export const ProjectSchemas = {
 			.string()
 			.regex(/^(?:(?:https?):\/\/)?(?:[\w-]+\.)+[a-z]{2,}(?:\/[^\s]*)?$/)
 			.transform((u) => (u.startsWith("http") ? u : `https://${u}`)),
+		baseTemplate: z.string().nullish(),
+		unsubscribeFooter: z.string().nullish(),
+		templatingLanguage: templatingLanguage.default("DEFAULT"),
 	}),
 	analytics: z.object({
 		method: z.enum(["week", "month", "year"]).default("week"),

--- a/packages/shared/src/templates.ts
+++ b/packages/shared/src/templates.ts
@@ -1,0 +1,362 @@
+export const DEFAULT_FOOTER = `<mj-divider border-width="2px" border-color="#f5f5f5"></mj-divider>
+<mj-text align="center">
+  <p style="color: #a3a3a3; text-decoration: none; font-size: 12px; line-height: 1.7142857;">
+    You received this email because you agreed to receive emails from {{project_name}}. If you no longer wish to receive emails like this, please <a style="text-decoration: underline" href="{{unsubscribe_url}}" target="_blank">update your preferences</a>.
+  </p>
+</mj-text>`;
+
+export const DEFAULT_BASE_TEMPLATE = `<mjml>
+  <mj-head>
+    <mj-font name="Inter" href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" />
+    <mj-style inline="inline">
+      .prose {
+        color: #4a5568;
+        max-width: 600px;
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+      }
+
+      .prose [class~="lead"] {
+        color: #4a5568;
+        font-size: 20px;
+        line-height: 32px;
+        margin-top: 19px;
+        margin-bottom: 19px;
+      }
+
+      .prose a {
+        color: #1a202c;
+        text-decoration: underline;
+      }
+
+      .prose strong {
+        color: #1a202c;
+        font-weight: 600;
+      }
+
+      .prose ol {
+        counter-reset: list-counter;
+        margin-top: 20px;
+        margin-bottom: 20px;
+      }
+
+      .prose ol > li {
+        position: relative;
+        counter-increment: list-counter;
+        padding-left: 28px;
+      }
+
+      .prose ol > li::before {
+        content: counter(list-counter) ".";
+        position: absolute;
+        font-weight: 400;
+        color: #718096;
+      }
+
+      .prose ul > li {
+        position: relative;
+        padding-left: 28px;
+      }
+
+      .prose ul > li::before {
+        content: "";
+        position: absolute;
+        background-color: #cbd5e0;
+        border-radius: 50%;
+        width: 6px;
+        height: 6px;
+        top: 11px;
+        left: 4px;
+      }
+
+      .prose hr {
+        border-color: #e2e8f0;
+        border-top-width: 1px;
+        margin-top: 42px;
+        margin-bottom: 42px;
+      }
+
+      .prose blockquote {
+        font-weight: 500;
+        font-style: italic;
+        color: #1a202c;
+        border-left: 4px solid #e2e8f0;
+        quotes: initial;
+        margin-top: 25px;
+        margin-bottom: 25px;
+        padding-left: 16px;
+      }
+
+      .prose h1 {
+        color: #1a202c;
+        font-weight: 800;
+        font-size: 36px;
+        margin-top: 0px;
+        margin-bottom: 14px;
+        line-height: 40px;
+      }
+
+      .prose h2 {
+        color: #1a202c;
+        font-weight: 700;
+        font-size: 24px;
+        margin-top: 32px;
+        margin-bottom: 16px;
+        line-height: 32px;
+      }
+
+      .prose h3 {
+        color: #1a202c;
+        font-weight: 600;
+        font-size: 20px;
+        margin-top: 25px;
+        margin-bottom: 9.6px;
+        line-height: 32px;
+      }
+
+      .prose h4 {
+        color: #1a202c;
+        font-weight: 600;
+        margin-top: 24px;
+        margin-bottom: 8px;
+        line-height: 1.5;
+      }
+
+      .prose figure figcaption {
+        color: #718096;
+        font-size: 14px;
+        line-height: 1.4;
+        margin-top: 14px;
+      }
+
+      .prose code {
+        color: #1a202c;
+        font-weight: 600;
+        font-size: 14px;
+      }
+
+      .prose code::before {
+        content: "\`";
+      }
+
+      .prose code::after {
+        content: "\`";
+      }
+
+      .prose pre {
+        color: #e2e8f0;
+        background-color: #2d3748;
+        overflow-x: auto;
+        font-size: 14px;
+        line-height: 1.7142857;
+        margin-top: 27px;
+        margin-bottom: 27px;
+        border-radius: 6px;
+        padding-top: 13px;
+        padding-right: 18px;
+        padding-bottom: 13px;
+        padding-left: 18px;
+      }
+
+      .prose pre code {
+        background-color: transparent;
+        border-width: 0;
+        border-radius: 0;
+        padding: 0;
+        font-weight: 400;
+        color: inherit;
+        font-size: inherit;
+        font-family: inherit;
+        line-height: inherit;
+      }
+
+      .prose pre code::before {
+        content: "";
+      }
+
+      .prose pre code::after {
+        content: "";
+      }
+
+      .prose table {
+        width: 100%;
+        table-layout: auto;
+        margin-top: 32px;
+        margin-bottom: 32px;
+        font-size: 11px;
+        line-height: 1.7142857;
+      }
+
+      .prose thead {
+        color: #1a202c;
+        font-weight: 600;
+        border-bottom: 1px solid #cbd5e0;
+      }
+
+      .prose thead th {
+        vertical-align: bottom;
+        padding-right: 9px;
+        padding-bottom: 9px;
+        padding-left: 9px;
+      }
+
+      .prose tbody tr {
+        border-bottom: 1px solid #e2e8f0;
+      }
+
+      .prose tbody tr:last-child {
+        border-bottom-width: 0;
+      }
+
+      .prose tbody td {
+        vertical-align: top;
+        padding-top: 9px;
+        padding-right: 9px;
+        padding-bottom: 9px;
+        padding-left: 9px;
+      }
+
+      .prose {
+        font-size: 16px;
+        line-height: 1.75;
+      }
+
+      .prose p {
+        margin-top: 20px;
+        margin-bottom: 20px;
+      }
+
+      .prose img {
+        margin-top: 32px;
+        margin-bottom: 32px;
+        max-width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      .prose video {
+        margin-top: 32px;
+        margin-bottom: 32px;
+      }
+
+      .prose figure {
+        margin-top: 32px;
+        margin-bottom: 32px;
+      }
+
+      .prose figure > * {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
+      .prose h2 code {
+        font-size: 14px;
+      }
+
+      .prose h3 code {
+        font-size: 14px;
+      }
+
+      .prose ul {
+        margin-top: 20px;
+        margin-bottom: 20px;
+      }
+
+      .prose li {
+        margin-top: 8px;
+        margin-bottom: 8px;
+      }
+
+      .prose ol > li:before {
+        left: 0;
+      }
+
+      .prose > ul > li p {
+        margin-top: 12px;
+        margin-bottom: 12px;
+      }
+
+      .prose > ul > li > *:first-child {
+        margin-top: 20px;
+      }
+
+      .prose > ul > li > *:last-child {
+        margin-bottom: 20px;
+      }
+
+      .prose > ol > li > *:first-child {
+        margin-top: 20px;
+      }
+
+      .prose > ol > li > *:last-child {
+        margin-bottom: 20px;
+      }
+
+      .prose ul ul,
+      .prose ul ol,
+      .prose ol ul,
+      .prose ol ol {
+        margin-top: 12px;
+        margin-bottom: 12px;
+      }
+
+      .prose hr + * {
+        margin-top: 0;
+      }
+
+      .prose h2 + * {
+        margin-top: 0;
+      }
+
+      .prose h3 + * {
+        margin-top: 0;
+      }
+
+      .prose h4 + * {
+        margin-top: 0;
+      }
+
+      .prose thead th:first-child {
+        padding-left: 0;
+      }
+
+      .prose thead th:last-child {
+        padding-right: 0;
+      }
+
+      .prose tbody td:first-child {
+        padding-left: 0;
+      }
+
+      .prose tbody td:last-child {
+        padding-right: 0;
+      }
+
+      .prose > :first-child {
+        margin-top: 0;
+      }
+
+      .prose > :last-child {
+        margin-bottom: 0;
+      }
+    </mj-style>
+  </mj-head>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-raw>
+          <tr class="prose prose-neutral">
+            <td style="padding:10px 25px;word-break:break-word">
+              {{html}}
+            </td>
+          </tr>
+        </mj-raw>
+      </mj-column>
+    </mj-section>
+     <mj-section>
+      <mj-column>
+        {{unsubscribe_footer}}
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`;

--- a/prisma/migrations/20250906095500_project_base_template/migration.sql
+++ b/prisma/migrations/20250906095500_project_base_template/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "projects" ADD COLUMN     "baseTemplate" TEXT,
+ADD COLUMN     "unsubscribeFooter" TEXT,
+ADD COLUMN     "templatingLanguage" TEXT NOT NULL DEFAULT 'DEFAULT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,10 @@ model Project {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  baseTemplate String?
+  unsubscribeFooter String?
+  templatingLanguage String? @default("DEFAULT")
+
   @@map("projects")
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,6 +2993,7 @@ __metadata:
     dotenv: "npm:^16.4.5"
     express: "npm:^4.19.2"
     express-async-errors: "npm:^3.1.1"
+    handlebars: "npm:^4.7.8"
     helmet: "npm:^7.1.0"
     ioredis: "npm:^5.4.1"
     jsonwebtoken: "npm:^9.0.2"
@@ -7510,7 +7511,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.7":
+"handlebars@npm:^4.7.7, handlebars@npm:^4.7.8":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
   dependencies:


### PR DESCRIPTION
 - Adds support for customizing the "base" template
 - Adds support for using handlebars for templating as an option
 - The unsubscribe footer is inserted into the Plunk template but also used to generate the HTML footer by running it through MJML
 - I also added a script to run a local SES mock server to help with testing without sending emails, I considered adding it to the docker compose setup but I couldn't find an image that worked on my mac
<img width="1795" height="934" alt="image" src="https://github.com/user-attachments/assets/85377203-218c-4b9a-8090-518ed82bbef4" />
