### PR TITLE
refactor: remove recipients from campaign data structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "plunk",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"private": true,
 	"license": "agpl-3.0",
 	"workspaces": {

--- a/packages/api/src/services/ProjectService.ts
+++ b/packages/api/src/services/ProjectService.ts
@@ -285,7 +285,6 @@ export class ProjectService {
 		return wrapRedis(Keys.Project.campaigns(id), async () => {
 			return prisma.project.findUnique({ where: { id } }).campaigns({
 				include: {
-					recipients: { select: { id: true } },
 					emails: { select: { id: true, status: true } },
 					tasks: { select: { id: true } },
 				},

--- a/packages/dashboard/src/lib/hooks/campaigns.ts
+++ b/packages/dashboard/src/lib/hooks/campaigns.ts
@@ -25,9 +25,6 @@ export function useCampaigns() {
       tasks: {
         id: string;
       }[];
-      recipients: {
-        id: string;
-      }[];
     })[]
   >(activeProject ? `/projects/id/${activeProject.id}/campaigns` : null);
 }

--- a/packages/dashboard/src/pages/campaigns/index.tsx
+++ b/packages/dashboard/src/pages/campaigns/index.tsx
@@ -90,11 +90,6 @@ export default function Index() {
 																<h2 className={"col-span-2 truncate font-semibold text-neutral-700"}>Properties</h2>
 																<div className={"grid grid-cols-2 gap-3"}>
 																	<div>
-																		<label className={"text-xs font-medium text-neutral-500"}>Recipients</label>
-																		<p className="mt-1 truncate text-sm text-neutral-500">{c.recipients.length}</p>
-																	</div>
-
-																	<div>
 																		<label className={"text-xs font-medium text-neutral-500"}>Status</label>
 																		<p className="mt-1 truncate text-sm text-neutral-500">
 																			{c.status === "DRAFT" ? (


### PR DESCRIPTION
This PR removes the recipients count from the campaigns list page as it appears to slow down the campaigns page for some users.