### PR TITLE
fix: format fulldate for campaign sent time

### DIFF
--- a/apps/web/src/pages/campaigns/[id].tsx
+++ b/apps/web/src/pages/campaigns/[id].tsx
@@ -1020,11 +1020,11 @@ export default function CampaignDetailsPage() {
               {/* Sent At */}
               {c.sentAt && (
                 <div className="pb-3 border-b border-neutral-100">
-                  <p className="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Sent At</p>
+                  <p className="text-xs font-medium text-neutral-500 uppercase tracking-wide mb-2">Sent On</p>
                   <div className="flex items-center gap-2">
                     <Send className="h-4 w-4 text-neutral-400" />
                     <p className="text-sm font-medium text-neutral-900">
-                      {new Date(c.sentAt).toLocaleDateString()} at {new Date(c.sentAt).toLocaleTimeString()}
+                      {formatFullDateTime(new Date(c.sentAt))}
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Description
Format the campaign sent time to look uniform with other dates on the app. 

Before:
<img width="386" height="88" alt="Screenshot 2025-12-11 at 20 04 24" src="https://github.com/user-attachments/assets/471ff053-9a88-4ec3-8c05-5bdfcdac1e9d" />

After:
<img width="379" height="83" alt="Screenshot 2025-12-11 at 20 03 40" src="https://github.com/user-attachments/assets/27412891-ab1b-4424-ba46-8e41808f2f94" />



## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `feat:` New feature (MINOR version bump)
- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## PR Title Format
fix: format fulldate for campaign sent time

<!--
Your PR title should follow conventional commits format:
✅ feat: add email template editor
✅ fix: resolve memory leak in worker
✅ feat!: redesign API authentication
❌ Added new feature (missing type prefix)

See VERSIONING.md for more details
-->

## Testing

<!-- Describe how you tested your changes -->

## Checklist

- [ ] PR title follows conventional commits format
- [ ] Code builds successfully
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)

## Related Issues

<!-- Link any related issues here -->
Closes #
