### PR TITLE
style: Remove active line background color in HtmlEditor

### DIFF
--- a/apps/web/src/components/EmailEditor/HtmlEditor.tsx
+++ b/apps/web/src/components/EmailEditor/HtmlEditor.tsx
@@ -38,9 +38,7 @@ export function HtmlEditor({value, onChange, placeholder}: HtmlEditorProps) {
       backgroundColor: '#f3f4f6',
       color: '#374151',
     },
-    '.cm-activeLine': {
-      backgroundColor: '#f9fafb',
-    },
+
     '.cm-selectionBackground, ::selection': {
       backgroundColor: '#dbeafe !important',
     },


### PR DESCRIPTION
## Description
This PR fixes a CSS issue where the text selection color/background was not properly defined, causing the selection to be visually invisible. The fix ensures that when text is selected, it has a visible background and color.

## Type of Change
- [x] `fix:` Bug fix (PATCH version bump)

## PR Title Format

- ✅ fix: resolve text selection color issue

## Testing
- I tested the changes by selecting text in the editor and confirming that the selection is now visible with a background color and text color.

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally (if applicable)
- [x] Documentation updated (if needed)

## Related Issues
Closes #244
