### PR TITLE
feat: add French (fr) locale for contact-facing pages

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -2,6 +2,7 @@ import type {Language} from './languages.js';
 // Static imports for all translation files
 import enTranslations from './locales/en.json' with {type: 'json'};
 import nlTranslations from './locales/nl.json' with {type: 'json'};
+import frTranslations from './locales/fr.json' with {type: 'json'};
 
 export {
   SUPPORTED_LANGUAGES,
@@ -29,6 +30,7 @@ export interface Translations {
 const translationsMap: Record<string, Translations> = {
   en: enTranslations,
   nl: nlTranslations,
+  fr: frTranslations,
 };
 
 // In-memory cache for loaded translations

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -8,6 +8,7 @@ export interface Language {
 export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸'},
   {code: 'nl', name: 'Dutch', nativeName: 'Nederlands', flag: '🇳🇱'},
+  {code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/fr.json
+++ b/packages/shared/src/i18n/locales/fr.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "Se désabonner",
+      "description": "Nous sommes désolés de vous voir partir. Êtes-vous sûr de vouloir désabonner {email} de la réception des e-mails ?",
+      "button": "Se désabonner",
+      "buttonLoading": "Désabonnement en cours...",
+      "managePreferences": "Gérer les préférences",
+      "successTitle": "Vous êtes désabonné",
+      "successDescription": "{email} a été désabonné. Vous ne recevrez plus nos e-mails.",
+      "changedMind": "Vous avez changé d’avis ?",
+      "subscribeAgain": "Se réabonner"
+    },
+    "subscribe": {
+      "title": "S’abonner aux mises à jour",
+      "description": "Souhaitez-vous abonner {email} pour recevoir des e-mails ?",
+      "button": "S’abonner",
+      "buttonLoading": "Abonnement en cours...",
+      "successTitle": "Vous êtes abonné !",
+      "successDescription": "{email} est maintenant abonné pour recevoir nos e-mails."
+    },
+    "manage": {
+      "title": "Gérer les préférences",
+      "description": "Gérez les préférences e-mail pour {email}",
+      "subscriptionLabel": "Abonnement e-mail",
+      "subscribedStatus": "Vous êtes actuellement abonné",
+      "unsubscribedStatus": "Vous êtes actuellement désabonné",
+      "subscribedSuccess": "Abonné avec succès !",
+      "unsubscribedSuccess": "Désabonné avec succès !",
+      "unsubscribeCompletely": "Se désabonner complètement",
+      "subscribeToEmails": "S’abonner aux e-mails",
+      "disclaimer": "Cette page vous permet de gérer vos préférences e-mail. Votre statut d’abonnement est mis à jour en temps réel."
+    },
+    "common": {
+      "loading": "Chargement...",
+      "error": "Erreur"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "Vous recevez cet e-mail parce que vous avez accepté de recevoir des e-mails de la part de {projectName}. Si vous ne souhaitez plus recevoir d’e-mails de ce type, veuillez",
+      "updatePreferences": "mettre à jour vos préférences"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new French (`fr`) locale for the contact-facing pages and the unsubscribe email footer.
It includes the French translation file and wires it into the shared i18n loader and supported languages list.

## Type of Change

- [x] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Testing

- Built `@plunk/db` (required dependency) and `@plunk/shared` successfully:
  - `yarn workspace @plunk/db run build`
  - `yarn workspace @plunk/shared run build`

## Related Issues

Closes #246