### PR TITLE
feat(i18n): add Hindi translations for contact-facing pages

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -3,7 +3,7 @@ import type {Language} from './languages.js';
 import enTranslations from './locales/en.json' with {type: 'json'};
 import nlTranslations from './locales/nl.json' with {type: 'json'};
 import frTranslations from './locales/fr.json' with {type: 'json'};
-
+import hiTranslations from './locales/hi.json' with {type: 'json'};
 export {
   SUPPORTED_LANGUAGES,
   DEFAULT_LANGUAGE,
@@ -31,6 +31,7 @@ const translationsMap: Record<string, Translations> = {
   en: enTranslations,
   nl: nlTranslations,
   fr: frTranslations,
+  hi: hiTranslations,
 };
 
 // In-memory cache for loaded translations

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -9,6 +9,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'en', name: 'English', nativeName: 'English', flag: '🇺🇸'},
   {code: 'nl', name: 'Dutch', nativeName: 'Nederlands', flag: '🇳🇱'},
   {code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷'},
+  {code: 'hi', name: 'Hindi', nativeName: 'हिंदी', flag: '🇮🇳'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/hi.json
+++ b/packages/shared/src/i18n/locales/hi.json
@@ -1,0 +1,46 @@
+{
+    "pages": {
+      "unsubscribe": {
+        "title": "अनवस्थापित करें",
+        "description": "हम आपको छोड़ने के लिए खेद है। क्या आप यकीन है कि आप {email} से ईमेल प्राप्त करना चाहते हैं?",
+        "button": "अनवस्थापित करें",
+        "buttonLoading": "अनवस्थापित कर रहा है...",
+        "managePreferences": "प्राथमिकताओं को बदलें",
+        "successTitle": "आप अनवस्थापित हैं",
+        "successDescription": "{email} अनवस्थापित हो गया है। आपको हमारे से और कोई ईमेल नहीं मिलेगा।",
+        "changedMind": "आपके मन में क्या परिवर्तन है?",
+        "subscribeAgain": "पुनः सदस्यता लें"
+      },
+      "subscribe": {
+        "title": "सदस्यता लें",
+        "description": "क्या आप यकीन है कि आप {email} से ईमेल प्राप्त करना चाहते हैं?",
+        "button": "सदस्यता लें",
+        "buttonLoading": "सदस्यता ले रहा है...",
+        "successTitle": "आप सदस्यता ले गए हैं!",
+        "successDescription": "{email} अब हमारे से ईमेल प्राप्त करने के लिए सदस्यता ले गया है।"
+      },
+      "manage": {
+        "title": "प्राथमिकताओं को बदलें",
+        "description": "ईमेल प्राथमिकताओं को बदलें {email}",
+        "subscriptionLabel": "ईमेल सदस्यता",
+        "subscribedStatus": "आप अभी ईमेल प्राप्त करने के लिए सदस्यता ले गए हैं",
+        "unsubscribedStatus": "आप अभी ईमेल से अनवस्थापित हैं",
+        "subscribedSuccess": "सदस्यता ले गई!",
+        "unsubscribedSuccess": "अनवस्थापित गई!",
+        "unsubscribeCompletely": "पूरी तरह से अनवस्थापित करें",
+        "subscribeToEmails": "ईमेल सदस्यता लें",
+        "disclaimer": "यह पृष्ठ आपको ईमेल प्राथमिकताओं को बदलने देता है। आपकी सदस्यता स्थिति अभी ही अपडेट हो जाती है।"
+      },
+      "common": {
+        "loading": "लोड हो रहा है...",
+        "error": "त्रुटि"
+      }
+    },
+    "email": {
+      "footer": {
+        "unsubscribeText": "आपको यह ईमेल मिला है क्योंकि आपने {projectName} से ईमेल प्राप्त करने को सहमत हैं। यदि आप इस तरह के ईमेल प्राप्त करना चाहते हैं, तो कृपया",
+        "updatePreferences": "अपनी प्राथमिकताओं को बदलें"
+      }
+    }
+  }
+  


### PR DESCRIPTION
- Add hi.json locale file with Hindi translations
- Add Hindi language to SUPPORTED_LANGUAGES
- Import Hindi translations in i18n index

Closes #246

## Description

This PR adds Hindi (🇮🇳 हिंदी) as a supported language for Plunk's contact-facing pages including:
- Unsubscribe page
- Subscribe page  
- Manage preferences page
- Email footer text

## Type of Change

- [x] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## PR Title Format

✅ feat(i18n): add Hindi translations for contact-facing pages

## Testing

- Verified translations load correctly using `loadTranslationsSync('hi')`
- Confirmed all translation keys match the English locale structure
- Tested variable interpolation (e.g., `{email}`, `{projectName}`) works correctly

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)

## Related Issues

Closes #246
