### PR TITLE
feat(i18n): add German translations for the contact-facing pages

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -3,6 +3,7 @@ import type {Language} from './languages.js';
 import enTranslations from './locales/en.json' with {type: 'json'};
 import nlTranslations from './locales/nl.json' with {type: 'json'};
 import frTranslations from './locales/fr.json' with {type: 'json'};
+import deTranslations from './locales/de.json' with {type: 'json'};
 import hiTranslations from './locales/hi.json' with {type: 'json'};
 export {
   SUPPORTED_LANGUAGES,
@@ -30,6 +31,7 @@ export interface Translations {
 const translationsMap: Record<string, Translations> = {
   en: enTranslations,
   nl: nlTranslations,
+  de: deTranslations,
   fr: frTranslations,
   hi: hiTranslations,
 };

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -10,6 +10,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'nl', name: 'Dutch', nativeName: 'Nederlands', flag: '🇳🇱'},
   {code: 'fr', name: 'French', nativeName: 'Français', flag: '🇫🇷'},
   {code: 'hi', name: 'Hindi', nativeName: 'हिंदी', flag: '🇮🇳'},
+  {code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/de.json
+++ b/packages/shared/src/i18n/locales/de.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "Abmelden",
+      "description": "Es tut uns leid, dass Sie gehen. Sind Sie sicher, dass Sie {email} vom Empfang von E-Mails abmelden möchten?",
+      "button": "Abmelden",
+      "buttonLoading": "Abmeldung wird bearbeitet...",
+      "managePreferences": "Einstellungen verwalten",
+      "successTitle": "Sie sind abgemeldet",
+      "successDescription": "{email} wurde abgemeldet. Sie werden keine E-Mails mehr von uns erhalten.",
+      "changedMind": "Haben Sie Ihre Meinung geändert?",
+      "subscribeAgain": "Erneut abonnieren"
+    },
+    "subscribe": {
+      "title": "Updates abonnieren",
+      "description": "Möchten Sie {email} abonnieren, um E-Mails zu erhalten?",
+      "button": "Abonnieren",
+      "buttonLoading": "Abonnement wird bearbeitet...",
+      "successTitle": "Sie sind abonniert!",
+      "successDescription": "{email} ist jetzt abonniert, um unsere E-Mails zu erhalten."
+    },
+    "manage": {
+      "title": "Einstellungen verwalten",
+      "description": "E-Mail-Einstellungen für {email} verwalten",
+      "subscriptionLabel": "E-Mail-Abonnement",
+      "subscribedStatus": "Sie sind derzeit abonniert",
+      "unsubscribedStatus": "Sie sind derzeit nicht abonniert",
+      "subscribedSuccess": "Erfolgreich abonniert!",
+      "unsubscribedSuccess": "Erfolgreich abgemeldet!",
+      "unsubscribeCompletely": "Vollständig abmelden",
+      "subscribeToEmails": "E-Mails abonnieren",
+      "disclaimer": "Auf dieser Seite können Sie Ihre E-Mail-Einstellungen verwalten. Ihr Abonnementstatus wird in Echtzeit aktualisiert."
+    },
+    "common": {
+      "loading": "Wird geladen...",
+      "error": "Fehler"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "Sie erhalten diese E-Mail, weil Sie dem Empfang von E-Mails von {projectName} zugestimmt haben. Wenn Sie solche E-Mails nicht mehr erhalten möchten, bitte",
+      "updatePreferences": "aktualisieren Sie Ihre Einstellungen"
+    }
+  }
+}


### PR DESCRIPTION
**Description**

This PR adds a new German (de) locale for the contact-facing pages and the unsubscribe email footer.
It includes the German translation file and wires it into the shared i18n loader and supported languages list.

**Type of Change**  

- [x] feat: New feature (MINOR version bump)  
- [ ] fix: Bug fix (PATCH version bump)  
- [ ] feat!: Breaking change - new feature (MAJOR version bump)  
- [ ] fix!: Breaking change - bug fix (MAJOR version bump)  
- [ ] docs: Documentation update (no version bump)  
- [ ] chore: Maintenance/dependencies (no version bump)  
- [ ] refactor: Code refactoring (no version bump)  
- [ ] test: Adding tests (no version bump)  
- [ ] perf: Performance improvement (PATCH version bump)

**Related Issues** 

Closes #246