### PR TITLE
Use environment variables for SMTP port configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,8 +202,8 @@ services:
 
     ports:
       # SMTP ports (for email relay)
-      - "465:465"    # SMTPS (implicit TLS)
-      - "587:587"    # SMTP Submission (STARTTLS)
+      - "${PORT_SECURE:-465}:465"    # SMTPS (implicit TLS)
+      - "${PORT_SUBMISSION:-587}:587"    # SMTP Submission (STARTTLS)
       # Optional: Expose individual service ports for debugging
       # - "8080:8080"  # API
       # - "3000:3000"  # Web


### PR DESCRIPTION
## Description

Replaces the hardcoded SMTPS and SMTP Submission ports with the SMTP ports defined in the env.self-host.example. 

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [x] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## PR Title Format

Use environment variables for SMTP port configuration