### PR TITLE
feat(i18n): Add Bulgarian translations

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -6,6 +6,7 @@ import frTranslations from './locales/fr.json' with {type: 'json'};
 import deTranslations from './locales/de.json' with {type: 'json'};
 import hiTranslations from './locales/hi.json' with {type: 'json'};
 import ptTranslations from './locales/pt.json' with {type: 'json'};
+import bgTranslations from './locales/bg.json' with {type: 'json'};
 export {
   SUPPORTED_LANGUAGES,
   DEFAULT_LANGUAGE,
@@ -36,6 +37,7 @@ const translationsMap: Record<string, Translations> = {
   fr: frTranslations,
   hi: hiTranslations,
   pt: ptTranslations,
+  bg: bgTranslations,
 };
 
 // In-memory cache for loaded translations

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'hi', name: 'Hindi', nativeName: 'हिंदी', flag: '🇮🇳'},
   {code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪'},
   {code: 'pt', name: 'Portuguese', nativeName: 'Português', flag: '🇧🇷'},
+  {code: 'bg', name: 'Bulgarian', nativeName: 'Български', flag: '🇧🇬'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/bg.json
+++ b/packages/shared/src/i18n/locales/bg.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "Отписване",
+      "description": "Съжаляваме, че си тръгвате. Сигурни ли сте, че искате да отпишете {email} от получаването на имейли?",
+      "button": "Отпиши",
+      "buttonLoading": "Отписване...",
+      "managePreferences": "Управлявай настройки",
+      "successTitle": "Отписани сте",
+      "successDescription": "{email} е отписан. Няма да получавате повече имейли от нас.",
+      "changedMind": "Размислихте?",
+      "subscribeAgain": "Абонирай се пак"
+    },
+    "subscribe": {
+      "title": "Абонамент за новини",
+      "description": "Искате ли да абонирате {email} за имейли?",
+      "button": "Абонирай",
+      "buttonLoading": "Абониране...",
+      "successTitle": "Абонирани сте!",
+      "successDescription": "{email} вече е абониран за имейли от нас."
+    },
+    "manage": {
+      "title": "Настройки",
+      "description": "Настройки за {email}",
+      "subscriptionLabel": "Абонамент",
+      "subscribedStatus": "В момента сте абониран",
+      "unsubscribedStatus": "В момента сте отписан",
+      "subscribedSuccess": "Успешно абониране!",
+      "unsubscribedSuccess": "Успешно отписване!",
+      "unsubscribeCompletely": "Пълно отписване",
+      "subscribeToEmails": "Абонирай за имейли",
+      "disclaimer": "Тук управлявате имейл настройките си. Статусът се обновява веднага."
+    },
+    "common": {
+      "loading": "Зарежда...",
+      "error": "Грешка"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "Получихте този имейл, защото сте се съгласили да получавате имейли от {projectName}. Ако не желаете повече такива имейли, моля",
+      "updatePreferences": "променете настройките"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds Bulgarian translation for the contact-facing pages as per #246 

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [x] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## PR Title Format
feat(i18n): Add Bulgarian translation for the contact-facing pages
 
<!--
Your PR title should follow conventional commits format:
✅ feat: add email template editor
✅ fix: resolve memory leak in worker
✅ feat!: redesign API authentication
❌ Added new feature (missing type prefix)

See VERSIONING.md for more details
-->

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [ ] Documentation updated (if needed)
