### PR TITLE
fix: Ensure template type is loaded before rendering Select

### DIFF
--- a/apps/web/src/pages/templates/[id].tsx
+++ b/apps/web/src/pages/templates/[id].tsx
@@ -118,7 +118,7 @@ export default function TemplateEditorPage() {
     }
   };
 
-  if (!template || !editedTemplate.type) {
+  if (!template || Object.keys(editedTemplate).length === 0) {
     return (
       <DashboardLayout>
         <div className="flex items-center justify-center min-h-[400px]">

--- a/apps/web/src/pages/templates/[id].tsx
+++ b/apps/web/src/pages/templates/[id].tsx
@@ -118,7 +118,7 @@ export default function TemplateEditorPage() {
     }
   };
 
-  if (!template) {
+  if (!template || !editedTemplate.type) {
     return (
       <DashboardLayout>
         <div className="flex items-center justify-center min-h-[400px]">


### PR DESCRIPTION
Addresses #242. The Select component renders with value={undefined} before useEffect populates editedTemplate.type. This triggers a React warning: 'Select is changing from uncontrolled to controlled.'

On the hosted environment, this likely causes Radix UI's data-placeholder attribute to remain set on the trigger, with the selected value text not being rendered despite the value being loaded in state.

This change extends the loading condition to wait for editedTemplate.type, ensuring the Select never renders in an undefined/uncontrolled state.

## Description

When editing a template, the Type dropdown appears empty even though the template has a type set. This forces users to re-select the type before saving any changes.

**Evidence from browser inspection:**
- Local prod: `<span style="pointer-events: none;">Transactional</span>`
- Hosted: `<button ... data-placeholder=""><span style="pointer-events: none;"></span>`

## Type of Change

- [x] `fix:` Bug fix (PATCH version bump)

## Testing

- Verified linting passes
- Confirmed the React warning appears on both local and hosted environments
- Could not reproduce the bug locally, but confirmed the root cause via browser DOM inspection on hosted (data-placeholder attribute and empty span)
- The fix prevents the Select from ever receiving an undefined value

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally

## Related Issues

#242
