### PR TITLE
feat(i18n): add Czech locale translations

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -7,6 +7,7 @@ import deTranslations from './locales/de.json' with {type: 'json'};
 import hiTranslations from './locales/hi.json' with {type: 'json'};
 import ptTranslations from './locales/pt.json' with {type: 'json'};
 import bgTranslations from './locales/bg.json' with {type: 'json'};
+import csTranslations from './locales/cs.json' with {type: 'json'};
 export {
   SUPPORTED_LANGUAGES,
   DEFAULT_LANGUAGE,
@@ -38,6 +39,7 @@ const translationsMap: Record<string, Translations> = {
   hi: hiTranslations,
   pt: ptTranslations,
   bg: bgTranslations,
+  cs: csTranslations,
 };
 
 // In-memory cache for loaded translations

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -13,6 +13,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'de', name: 'German', nativeName: 'Deutsch', flag: '🇩🇪'},
   {code: 'pt', name: 'Portuguese', nativeName: 'Português', flag: '🇧🇷'},
   {code: 'bg', name: 'Bulgarian', nativeName: 'Български', flag: '🇧🇬'},
+  {code: 'cs', name: 'Czech', nativeName: 'Čeština', flag: '🇨🇿'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/cs.json
+++ b/packages/shared/src/i18n/locales/cs.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "Odhlášení z odběru",
+      "description": "Mrzí nás, že odcházíte. Opravdu chcete odhlásit {email} z odběru e-mailů?",
+      "button": "Odhlásit se",
+      "buttonLoading": "Odhlašování...",
+      "managePreferences": "Spravovat předvolby",
+      "successTitle": "Odběr byl zrušen",
+      "successDescription": "E-mail {email} byl odhlášen z odběru. Už vám nebudeme zasílat žádné e-maily.",
+      "changedMind": "Změnili jste názor?",
+      "subscribeAgain": "Přihlásit se znovu"
+    },
+    "subscribe": {
+      "title": "Přihlášení k odběru",
+      "description": "Chcete přihlásit {email} k odběru e-mailů?",
+      "button": "Přihlásit se k odběru",
+      "buttonLoading": "Přihlašování...",
+      "successTitle": "Odběr byl aktivován!",
+      "successDescription": "E-mail {email} byl přihlášen k odběru e-mailů."
+    },
+    "manage": {
+      "title": "Správa předvoleb",
+      "description": "Správa e-mailových předvoleb pro {email}",
+      "subscriptionLabel": "Odběr e-mailů",
+      "subscribedStatus": "Aktuálně jste přihlášeni k odběru e-mailů",
+      "unsubscribedStatus": "Aktuálně jste odhlášeni z odběru e-mailů",
+      "subscribedSuccess": "Odběr byl úspěšně aktivován!",
+      "unsubscribedSuccess": "Odběr byl úspěšně zrušen!",
+      "unsubscribeCompletely": "Úplně se odhlásit z odběru",
+      "subscribeToEmails": "Přihlásit se k odběru e-mailů",
+      "disclaimer": "Na této stránce můžete spravovat své e-mailové předvolby. Stav odběru se aktualizuje v reálném čase."
+    },
+    "common": {
+      "loading": "Načítání...",
+      "error": "Chyba"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "Tento e-mail jste obdrželi, protože jste souhlasili se zasíláním e-mailů od {projectName}. Pokud si již nepřejete dostávat tyto e-maily, můžete",
+      "updatePreferences": "změnit své předvolby"
+    }
+  }
+}


### PR DESCRIPTION
Add Czech (cs) translations for contact-facing pages and email footers, and wire up the locale in the i18n system with the correct flag.

Ref #246