### PR TITLE
fix: correct cookie domain for .local TLD hostnames

### DIFF
--- a/apps/api/src/services/UserService.ts
+++ b/apps/api/src/services/UserService.ts
@@ -10,6 +10,7 @@ import {Keys} from './keys.js';
  * Extract base domain from URL for cookie sharing across subdomains
  * e.g., "http://api.example.com" -> ".example.com"
  * e.g., "http://api.localhost" -> ".localhost"
+ * e.g., "http://app.plunk.local" -> ".plunk.local"
  */
 function getCookieDomain(): string | undefined {
   if (NODE_ENV === 'development') {
@@ -28,9 +29,13 @@ function getCookieDomain(): string | undefined {
     // Extract base domain (last two parts for most domains, or .localhost)
     const parts = hostname.split('.');
     if (parts.length >= 2) {
-      // For *.localhost or *.local, use the full hostname with leading dot
-      if (hostname.endsWith('.localhost') || hostname.endsWith('.local')) {
+      // For *.localhost, use .localhost (reserved TLD)
+      if (hostname.endsWith('.localhost')) {
         return '.localhost';
+      }
+      // For *.local (mDNS TLD), use the actual base domain
+      if (hostname.endsWith('.local')) {
+        return `.${parts.slice(-2).join('.')}`;
       }
       // For other domains, use the last two parts (e.g., .example.com)
       return `.${parts.slice(-2).join('.')}`;


### PR DESCRIPTION
## Summary

Fixes #297

`getCookieDomain()` returns `'.localhost'` for hostnames ending in `.local` (e.g., `app.plunk.local`), causing the browser to reject the session cookie. This breaks dashboard authentication for self-hosted deployments using `.local` hostnames.

The fix splits the `.localhost` and `.local` cases so that `.local` hostnames return the actual base domain (e.g., `.plunk.local`).

## Changes

- Split the combined `.localhost || .local` condition into two separate checks
- `.localhost` hostnames continue to return `'.localhost'` (reserved TLD, correct behaviour)
- `.local` hostnames now return the actual base domain via `parts.slice(-2)` (e.g., `.plunk.local`)
- Updated the JSDoc to document the `.local` case

## Before / After

| Hostname | Before | After |
|----------|--------|-------|
| `api.plunk.localhost` | `.localhost` ✅ | `.localhost` ✅ |
| `app.plunk.local` | `.localhost` ❌ | `.plunk.local` ✅ |
| `api.example.com` | `.example.com` ✅ | `.example.com` ✅ |

## Testing

Discovered and verified on a self-hosted Plunk deployment (Raspberry Pi 5, ARM64, Docker). After patching this function in-container, dashboard login worked correctly with `.local` subdomains.