### PR TITLE
feat(dashboard): add link support for images in email editor

### DIFF
--- a/apps/web/src/components/EmailEditor/ResizableImage.tsx
+++ b/apps/web/src/components/EmailEditor/ResizableImage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {mergeAttributes, Node} from '@tiptap/core';
 import {NodeViewWrapper, type ReactNodeViewProps, ReactNodeViewRenderer} from '@tiptap/react';
+import {Link as LinkIcon} from 'lucide-react';
 import {useEffect, useRef, useState} from 'react';
 
 interface ImageAttrs {
@@ -9,6 +10,7 @@ interface ImageAttrs {
   title?: string;
   width?: number | string;
   height?: number | string;
+  href?: string | null;
 }
 
 function ResizableImageComponent({node, updateAttributes, selected}: ReactNodeViewProps) {
@@ -82,7 +84,7 @@ function ResizableImageComponent({node, updateAttributes, selected}: ReactNodeVi
     setResizeDirection(direction);
   };
 
-  const {src, alt, title, width, height} = attrs;
+  const {src, alt, title, width, height, href} = attrs;
 
   return (
     <NodeViewWrapper className="resizable-image-wrapper">
@@ -106,6 +108,30 @@ function ResizableImageComponent({node, updateAttributes, selected}: ReactNodeVi
             width: width ? `${width}px` : 'auto',
           }}
         />
+        {/* Link indicator badge */}
+        {href && selected && (
+          <div
+            style={{
+              position: 'absolute',
+              top: '4px',
+              left: '4px',
+              backgroundColor: '#3b82f6',
+              color: 'white',
+              borderRadius: '4px',
+              padding: '2px 6px',
+              fontSize: '11px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '3px',
+              zIndex: 10,
+              pointerEvents: 'none',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+            }}
+          >
+            <LinkIcon style={{width: '10px', height: '10px'}} />
+            Linked
+          </div>
+        )}
         {selected && (
           <>
             {/* Resize handles */}
@@ -227,11 +253,41 @@ export const ResizableImage = Node.create({
           };
         },
       },
+      href: {
+        default: null,
+        parseHTML: element => {
+          // When parsing <a href="..."><img></a>, extract href from parent anchor
+          const parent = element.parentElement;
+          if (parent?.tagName === 'A') {
+            return parent.getAttribute('href');
+          }
+          return null;
+        },
+        // href is not rendered as an img attribute — it's handled in renderHTML
+        renderHTML: () => ({}),
+      },
     };
   },
 
   parseHTML() {
     return [
+      {
+        // Match images wrapped in anchor tags (higher priority)
+        tag: 'a img[src]',
+        priority: 60,
+        getAttrs: (element: HTMLElement) => {
+          const img = element as HTMLImageElement;
+          const parent = img.parentElement;
+          return {
+            src: img.getAttribute('src'),
+            alt: img.getAttribute('alt'),
+            title: img.getAttribute('title'),
+            width: img.getAttribute('width') ? parseInt(img.getAttribute('width')!, 10) : null,
+            height: img.getAttribute('height') ? parseInt(img.getAttribute('height')!, 10) : null,
+            href: parent?.tagName === 'A' ? parent.getAttribute('href') : null,
+          };
+        },
+      },
       {
         tag: 'img[src]',
       },
@@ -239,7 +295,14 @@ export const ResizableImage = Node.create({
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['img', mergeAttributes(HTMLAttributes, {class: 'email-image'})];
+    const {href, ...imgAttrs} = HTMLAttributes;
+    const imgAttributes = mergeAttributes(imgAttrs, {class: 'email-image'});
+
+    if (href) {
+      return ['a', {href, target: '_blank', rel: 'noopener noreferrer'}, ['img', imgAttributes]];
+    }
+
+    return ['img', imgAttributes];
   },
 
   addNodeView() {
@@ -255,6 +318,16 @@ export const ResizableImage = Node.create({
             type: this.name,
             attrs: options,
           });
+        },
+      setImageLink:
+        (href: string) =>
+        ({commands}: {commands: {updateAttributes: (name: string, attrs: Record<string, unknown>) => boolean}}) => {
+          return commands.updateAttributes('image', {href});
+        },
+      removeImageLink:
+        () =>
+        ({commands}: {commands: {updateAttributes: (name: string, attrs: Record<string, unknown>) => boolean}}) => {
+          return commands.updateAttributes('image', {href: null});
         },
     };
   },

--- a/apps/web/src/components/EmailEditor/Toolbar.tsx
+++ b/apps/web/src/components/EmailEditor/Toolbar.tsx
@@ -60,10 +60,14 @@ export function Toolbar({editor, onInsertVariable, onInsertImage, canUploadImage
   const addLink = useCallback(() => {
     if (!editor) return;
     if (linkUrl) {
-      // If updating an existing link, extend selection to cover the entire link first
-      if (editor.isActive('link')) {
+      if (editor.isActive('image')) {
+        // Set link on selected image
+        (editor.chain().focus() as any).setImageLink(linkUrl).run();
+      } else if (editor.isActive('link')) {
+        // Update existing text link
         editor.chain().focus().extendMarkRange('link').setLink({href: linkUrl}).run();
       } else {
+        // Set new text link
         editor.chain().focus().setLink({href: linkUrl}).run();
       }
       setLinkUrl('');
@@ -73,7 +77,12 @@ export function Toolbar({editor, onInsertVariable, onInsertImage, canUploadImage
 
   const removeLink = useCallback(() => {
     if (!editor) return;
-    editor.chain().focus().unsetLink().run();
+    if (editor.isActive('image')) {
+      // Remove link from selected image
+      (editor.chain().focus() as any).removeImageLink().run();
+    } else {
+      editor.chain().focus().unsetLink().run();
+    }
     setLinkUrl('');
     setShowLinkInput(false);
   }, [editor]);
@@ -163,8 +172,13 @@ export function Toolbar({editor, onInsertVariable, onInsertImage, canUploadImage
   const handleToggleColorPicker = useCallback(() => setShowColorPicker(!showColorPicker), [showColorPicker]);
   const handleToggleLinkInput = useCallback(() => {
     if (!editor) return;
-    if (editor.isActive('link')) {
-      // Get the current link URL and show the input to edit it
+    if (editor.isActive('image')) {
+      // Get the current image link URL if it exists
+      const imageHref = editor.getAttributes('image').href || '';
+      setLinkUrl(imageHref);
+      setShowLinkInput(true);
+    } else if (editor.isActive('link')) {
+      // Get the current text link URL and show the input to edit it
       const previousUrl = editor.getAttributes('link').href || '';
       setLinkUrl(previousUrl);
       setShowLinkInput(true);
@@ -505,13 +519,16 @@ export function Toolbar({editor, onInsertVariable, onInsertImage, canUploadImage
           size="icon"
           onMouseDown={e => e.preventDefault()}
           onClick={handleToggleLinkInput}
-          data-active={editor.isActive('link')}
+          data-active={editor.isActive('link') || (editor.isActive('image') && !!editor.getAttributes('image').href)}
           className="h-8 w-8 data-[active=true]:bg-neutral-200"
         >
           <Link className="h-4 w-4" />
         </Button>
         {showLinkInput && (
           <div className="absolute top-10 right-0 bg-white border border-neutral-200 rounded-lg shadow-lg p-2 z-50 min-w-max">
+            {editor.isActive('image') && (
+              <p className="text-xs text-neutral-500 mb-1.5 px-1">Add link to image</p>
+            )}
             <div className="flex gap-2 mb-2">
               <input
                 type="url"
@@ -530,10 +547,12 @@ export function Toolbar({editor, onInsertVariable, onInsertImage, canUploadImage
                 autoFocus
               />
               <Button type="button" size="sm" onMouseDown={e => e.preventDefault()} onClick={addLink}>
-                {editor.isActive('link') ? 'Update' : 'Add'}
+                {editor.isActive('link') || (editor.isActive('image') && editor.getAttributes('image').href)
+                  ? 'Update'
+                  : 'Add'}
               </Button>
             </div>
-            {editor.isActive('link') && (
+            {(editor.isActive('link') || (editor.isActive('image') && editor.getAttributes('image').href)) && (
               <div className="flex justify-end">
                 <Button
                   type="button"


### PR DESCRIPTION
Closes #299

## Problem

The visual email editor strips `<a>` tags from images. When HTML containing `<a href="..."><img src="..."></a>` is loaded, the editor drops the anchor, leaving a bare `<img>`. There's no way to add, edit, or remove links on images — a fundamental requirement for email design (clickable logos, banners, thumbnails).

## Solution

Extends the `ResizableImage` Tiptap node extension with `href` attribute support and wires the existing toolbar link UI to work with images.

### Changes

**`ResizableImage.tsx`**
- Added `href` attribute with `parseHTML` that extracts the URL from a parent `<a>` tag
- Added `parseHTML` rule for `a img[src]` (priority 60) to match linked images before bare `<img>`
- Updated `renderHTML` to wrap the image in `<a href="..." target="_blank" rel="noopener noreferrer">` when `href` is set
- Added `setImageLink` and `removeImageLink` commands
- Added a visual "Linked" badge indicator on selected images that have a link

**`Toolbar.tsx`**
- Updated `addLink` to detect image selection and call `setImageLink` instead of `setLink`
- Updated `removeLink` to call `removeImageLink` for images
- Updated `handleToggleLinkInput` to pre-fill URL from image's `href` attribute
- Link button shows active state for linked images
- Shows "Add link to image" label when an image is selected
- Shows "Remove Link" button for linked images

### Behavior

- **Incoming HTML**: `<a href="https://example.com"><img src="logo.png"></a>` is parsed correctly — the image node stores `href` alongside `src`
- **Editor UI**: Clicking an image and then the link button opens the URL input. Entering a URL sets the image link.
- **Outgoing HTML**: Images with a link render as `<a href="..." target="_blank" rel="noopener noreferrer"><img src="..." /></a>`. Images without a link render as plain `<img>`.
- **Round-trip safe**: HTML with linked images can be loaded and saved without losing the links.

## Test plan

- [ ] Add an image in the visual editor, click it, click the link button, enter a URL — verify link is set
- [ ] Save and reload the template — verify link persists
- [ ] Switch to HTML view — verify image is wrapped in `<a>`
- [ ] Paste `<a><img></a>` HTML — verify the link is parsed and preserved
- [ ] Edit an existing image link — verify it updates
- [ ] Remove an image link — verify the `<a>` wrapper is removed
- [ ] Images without links still render as plain `<img>`
- [ ] Text link functionality is unaffected