### PR TITLE
feat(i18n): add Chinese translations (zh-TW, zh-HK, zh-CN)

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -11,6 +11,9 @@ import csTranslations from './locales/cs.json' with {type: 'json'};
 import plTranslations from './locales/pl.json' with {type: 'json'};
 import esTranslations from './locales/es.json' with {type: 'json'};
 import itTranslations from './locales/it.json' with {type: 'json'};
+import zhTWTranslations from './locales/zh-TW.json' with {type: 'json'};
+import zhHKTranslations from './locales/zh-HK.json' with {type: 'json'};
+import zhCNTranslations from './locales/zh-CN.json' with {type: 'json'};
 
 export {
   SUPPORTED_LANGUAGES,
@@ -47,6 +50,9 @@ const translationsMap: Record<string, Translations> = {
   pl: plTranslations,
   es: esTranslations,
   it: itTranslations,
+  'zh-TW': zhTWTranslations,
+  'zh-HK': zhHKTranslations,
+  'zh-CN': zhCNTranslations,
 };
 
 // In-memory cache for loaded translations

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -17,6 +17,9 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'pl', name: 'Polish', nativeName: 'Polski', flag: '🇵🇱'},
   {code: 'es', name: 'Spanish (Spain)', nativeName: 'Español (España)', flag: '🇪🇸'},
   {code: 'it', name: 'Italian', nativeName: 'Italiano', flag: '🇮🇹'},
+  {code: 'zh-TW', name: 'Chinese (Traditional, Taiwan)', nativeName: '繁體中文', flag: '🇹🇼'},
+  {code: 'zh-HK', name: 'Chinese (Traditional, Hong Kong)', nativeName: '繁體中文（香港）', flag: '🇭🇰'},
+  {code: 'zh-CN', name: 'Chinese (Simplified, China)', nativeName: '简体中文', flag: '🇨🇳'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/zh-CN.json
+++ b/packages/shared/src/i18n/locales/zh-CN.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "取消订阅",
+      "description": "确定要取消 {email} 的邮件订阅吗？",
+      "button": "取消订阅",
+      "buttonLoading": "处理中...",
+      "managePreferences": "改为管理偏好设置",
+      "successTitle": "已取消订阅",
+      "successDescription": "{email} 已取消订阅，你将不会再收到我们的邮件。",
+      "changedMind": "改变主意了吗？",
+      "subscribeAgain": "重新订阅"
+    },
+    "subscribe": {
+      "title": "订阅最新消息",
+      "description": "要为 {email} 订阅邮件吗？",
+      "button": "订阅",
+      "buttonLoading": "处理中...",
+      "successTitle": "订阅成功！",
+      "successDescription": "{email} 已订阅，你将会收到我们的最新消息。"
+    },
+    "manage": {
+      "title": "管理偏好设置",
+      "description": "管理 {email} 的邮件偏好设置",
+      "subscriptionLabel": "邮件订阅",
+      "subscribedStatus": "目前已订阅，会收到邮件通知",
+      "unsubscribedStatus": "目前已取消订阅",
+      "subscribedSuccess": "订阅成功！",
+      "unsubscribedSuccess": "已取消订阅！",
+      "unsubscribeCompletely": "取消订阅",
+      "subscribeToEmails": "订阅邮件",
+      "disclaimer": "你可以在此管理邮件偏好设置，订阅状态会实时更新。"
+    },
+    "common": {
+      "loading": "加载中...",
+      "error": "发生错误"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "你收到这封邮件是因为你订阅了 {projectName} 的邮件。如果你不想再收到这类邮件，请",
+      "updatePreferences": "更新你的偏好设置"
+    }
+  }
+}

--- a/packages/shared/src/i18n/locales/zh-HK.json
+++ b/packages/shared/src/i18n/locales/zh-HK.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "取消訂閱",
+      "description": "確定要取消 {email} 的電郵訂閱嗎？",
+      "button": "取消訂閱",
+      "buttonLoading": "處理中...",
+      "managePreferences": "改為管理偏好設定",
+      "successTitle": "已取消訂閱",
+      "successDescription": "{email} 已取消訂閱，你將不會再收到我們的電郵。",
+      "changedMind": "改變主意了嗎？",
+      "subscribeAgain": "重新訂閱"
+    },
+    "subscribe": {
+      "title": "訂閱最新消息",
+      "description": "要為 {email} 訂閱電郵嗎？",
+      "button": "訂閱",
+      "buttonLoading": "處理中...",
+      "successTitle": "訂閱成功！",
+      "successDescription": "{email} 已訂閱，你將會收到我們的最新消息。"
+    },
+    "manage": {
+      "title": "管理偏好設定",
+      "description": "管理 {email} 的電郵偏好設定",
+      "subscriptionLabel": "電郵訂閱",
+      "subscribedStatus": "目前已訂閱，會收到電郵通知",
+      "unsubscribedStatus": "目前已取消訂閱",
+      "subscribedSuccess": "訂閱成功！",
+      "unsubscribedSuccess": "已取消訂閱！",
+      "unsubscribeCompletely": "取消訂閱",
+      "subscribeToEmails": "訂閱電郵",
+      "disclaimer": "你可以在此管理電郵偏好設定，訂閱狀態會即時更新。"
+    },
+    "common": {
+      "loading": "載入中...",
+      "error": "發生錯誤"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "你收到這封電郵是因為你訂閱了 {projectName} 的電郵。如果你不想再收到這類電郵，請",
+      "updatePreferences": "更新你的偏好設定"
+    }
+  }
+}

--- a/packages/shared/src/i18n/locales/zh-TW.json
+++ b/packages/shared/src/i18n/locales/zh-TW.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "取消訂閱",
+      "description": "確定要取消 {email} 的郵件訂閱嗎？",
+      "button": "取消訂閱",
+      "buttonLoading": "處理中...",
+      "managePreferences": "改為管理偏好設定",
+      "successTitle": "已取消訂閱",
+      "successDescription": "{email} 已取消訂閱，你將不會再收到我們的郵件。",
+      "changedMind": "改變主意了嗎？",
+      "subscribeAgain": "重新訂閱"
+    },
+    "subscribe": {
+      "title": "訂閱最新消息",
+      "description": "要為 {email} 訂閱郵件嗎？",
+      "button": "訂閱",
+      "buttonLoading": "處理中...",
+      "successTitle": "訂閱成功！",
+      "successDescription": "{email} 已訂閱，你將會收到我們的最新消息。"
+    },
+    "manage": {
+      "title": "管理偏好設定",
+      "description": "管理 {email} 的郵件偏好設定",
+      "subscriptionLabel": "郵件訂閱",
+      "subscribedStatus": "目前已訂閱，會收到郵件通知",
+      "unsubscribedStatus": "目前已取消訂閱",
+      "subscribedSuccess": "訂閱成功！",
+      "unsubscribedSuccess": "已取消訂閱！",
+      "unsubscribeCompletely": "取消訂閱",
+      "subscribeToEmails": "訂閱郵件",
+      "disclaimer": "你可以在此管理郵件偏好設定，訂閱狀態會即時更新。"
+    },
+    "common": {
+      "loading": "載入中...",
+      "error": "發生錯誤"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "你收到這封信是因為你訂閱了 {projectName} 的郵件。如果你不想再收到這類郵件，請",
+      "updatePreferences": "更新你的偏好設定"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add three Chinese locale variants with region-specific flags, following the existing pattern of tying languages to specific regions (e.g. Spanish (Spain) 🇪🇸, Portuguese 🇧🇷):

- 🇹🇼 **zh-TW** — Traditional Chinese (Taiwan)
- 🇭🇰 **zh-HK** — Traditional Chinese (Hong Kong)
- 🇨🇳 **zh-CN** — Simplified Chinese (China)

Each variant uses region-appropriate terminology. For example, "email" is translated as 郵件 (TW), 電郵 (HK), and 邮件 (CN).

## Changes

- `packages/shared/src/i18n/locales/zh-TW.json` — Taiwan Traditional Chinese translations
- `packages/shared/src/i18n/locales/zh-HK.json` — Hong Kong Traditional Chinese translations
- `packages/shared/src/i18n/locales/zh-CN.json` — Simplified Chinese translations
- `packages/shared/src/i18n/languages.ts` — register all three in `SUPPORTED_LANGUAGES`
- `packages/shared/src/i18n/index.ts` — import and add to `translationsMap`

## Translated sections

| Section | zh-TW | zh-HK | zh-CN |
|---------|-------|-------|-------|
| Unsubscribe | 取消訂閱 | 取消訂閱 | 取消订阅 |
| Subscribe | 訂閱最新消息 | 訂閱最新消息 | 订阅最新消息 |
| Manage preferences | 管理偏好設定 | 管理偏好設定 | 管理偏好设置 |
| Email (term) | 郵件 | 電郵 | 邮件 |
| Loading | 載入中 | 載入中 | 加载中 |

## Test plan

- [x] Set project language to `zh-TW`, verify all contact-facing pages show Taiwan Traditional Chinese
- [x] Set project language to `zh-HK`, verify Hong Kong variant terminology (e.g. 電郵)
- [x] Set project language to `zh-CN`, verify Simplified Chinese
- [x] Send a marketing email for each locale, verify footer text
- [x] Verify fallback to English when locale is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)