### PR TITLE
fix: add alt text to email badge image

### DIFF
--- a/apps/api/src/services/EmailService.ts
+++ b/apps/api/src/services/EmailService.ts
@@ -1093,7 +1093,7 @@ export class EmailService {
                               <tr>
                                 <td style="width:180px;">
                                   <a href="${LANDING_URI}?ref=badge" target="_blank">
-                                    <img height="auto" src="https://cdn.useplunk.com/badge.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="180" />
+                                    <img alt="Powered by Plunk" height="auto" src="https://cdn.useplunk.com/badge.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="180" />
                                   </a>
                                 </td>
                               </tr>


### PR DESCRIPTION
## Summary
- add an `alt` attribute to the Plunk badge image appended to sent emails
- improve accessibility and avoid mail-tester penalties for images without alt text
- fixes #324

## Testing
- not run (small HTML output change)
