### PR TITLE
feat: add send test email for templates and use draft content

### DIFF
--- a/apps/api/src/controllers/Campaigns.ts
+++ b/apps/api/src/controllers/Campaigns.ts
@@ -309,8 +309,9 @@ export class Campaigns {
     const auth = res.locals.auth;
     const {id} = UtilitySchemas.id.parse(req.params);
     const {email} = CampaignSchemas.sendTest.parse(req.body);
+    const {subject, body, from, fromName, replyTo} = req.body;
 
-    await CampaignService.sendTest(auth.projectId, id!, email);
+    await CampaignService.sendTest(auth.projectId, id!, email, {subject, body, from, fromName, replyTo});
 
     return res.json({
       success: true,

--- a/apps/api/src/controllers/Templates.ts
+++ b/apps/api/src/controllers/Templates.ts
@@ -206,6 +206,36 @@ export class Templates {
   }
 
   /**
+   * POST /templates/:id/test
+   * Send a test email for a template
+   */
+  @Post(':id/test')
+  @Middleware([requireAuth, requireEmailVerified])
+  @CatchAsync
+  public async sendTest(req: Request, res: Response, _next: NextFunction) {
+    const auth = res.locals.auth;
+    const {id} = req.params;
+    const {email, subject, body, from, fromName, replyTo} = req.body;
+
+    if (!id) {
+      return res.status(400).json({error: 'Template ID is required'});
+    }
+
+    if (!email) {
+      return res.status(400).json({error: 'Email address is required'});
+    }
+
+    // Optional draft fields let the test send use what is currently in the
+    // editor rather than the last saved version.
+    await TemplateService.sendTest(auth.projectId!, id, email, {subject, body, from, fromName, replyTo});
+
+    return res.json({
+      success: true,
+      message: `Test email sent to ${email}`,
+    });
+  }
+
+  /**
    * GET /templates/:id/usage
    * Get template usage statistics
    */

--- a/apps/api/src/services/CampaignService.ts
+++ b/apps/api/src/services/CampaignService.ts
@@ -767,7 +767,12 @@ export class CampaignService {
   /**
    * Send a test email for a campaign
    */
-  public static async sendTest(projectId: string, campaignId: string, testEmail: string): Promise<void> {
+  public static async sendTest(
+    projectId: string,
+    campaignId: string,
+    testEmail: string,
+    draft?: {subject?: string; body?: string; from?: string; fromName?: string | null; replyTo?: string | null},
+  ): Promise<void> {
     const campaign = await this.get(projectId, campaignId);
 
     // Validate that the test email belongs to a project member
@@ -787,8 +792,15 @@ export class CampaignService {
       throw new HttpException(403, 'Test emails can only be sent to project members');
     }
 
+    // Prefer the draft the editor sent; fall back to the saved version.
+    const subject = draft?.subject || campaign.subject;
+    const body = draft?.body || campaign.body;
+    const fromEmail = draft?.from || campaign.from;
+    const fromName = draft?.fromName !== undefined ? draft.fromName : campaign.fromName;
+    const replyTo = draft?.replyTo !== undefined ? draft.replyTo : campaign.replyTo;
+
     // Verify domain is registered and verified before sending
-    await DomainService.verifyEmailDomain(campaign.from, projectId);
+    await DomainService.verifyEmailDomain(fromEmail, projectId);
 
     // Get project to validate from address
     const project = await prisma.project.findUnique({
@@ -813,15 +825,15 @@ export class CampaignService {
     // Prepare the email content (no variable replacement for test emails)
     await sendRawEmail({
       from: {
-        name: campaign.fromName || project.name || 'Plunk',
-        email: campaign.from,
+        name: fromName || project.name || 'Plunk',
+        email: fromEmail,
       },
       to: [testEmail],
       content: {
-        subject: `[TEST] ${campaign.subject}`,
-        html: campaign.body,
+        subject: `[TEST] ${subject}`,
+        html: body,
       },
-      reply: campaign.replyTo || undefined,
+      reply: replyTo || undefined,
       headers: buildEmailHeaders({
         emailClass,
         isCampaign: true,

--- a/apps/api/src/services/TemplateService.ts
+++ b/apps/api/src/services/TemplateService.ts
@@ -6,6 +6,8 @@ import {prisma} from '../database/prisma.js';
 import {HttpException} from '../exceptions/index.js';
 import type {ListSort} from '../utils/listSort.js';
 import {buildEmailFieldsUpdate} from '../utils/modelUpdate.js';
+import {DomainService} from './DomainService.js';
+import {sendRawEmail} from './SESService.js';
 
 export class TemplateService {
   /**
@@ -289,5 +291,71 @@ export class TemplateService {
       workflowSteps: workflowStepsCount,
       emailsSent: emailsCount,
     };
+  }
+
+  /**
+   * Send a test email for a template
+   * Only project members can receive test emails
+   */
+  public static async sendTest(
+    projectId: string,
+    templateId: string,
+    testEmail: string,
+    draft?: {subject?: string; body?: string; from?: string; fromName?: string | null; replyTo?: string | null},
+  ): Promise<void> {
+    const template = await this.get(projectId, templateId);
+
+    // Validate that the test email belongs to a project member
+    const membership = await prisma.membership.findFirst({
+      where: {
+        projectId,
+        user: {
+          email: testEmail,
+        },
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    if (!membership) {
+      throw new HttpException(403, 'Test emails can only be sent to project members');
+    }
+
+    // Prefer the draft the editor sent; fall back to the saved version.
+    const subject = draft?.subject || template.subject;
+    const body = draft?.body || template.body;
+    const fromEmail = draft?.from || template.from;
+    const fromName = draft?.fromName !== undefined ? draft.fromName : template.fromName;
+    const replyTo = draft?.replyTo !== undefined ? draft.replyTo : template.replyTo;
+
+    // Verify domain is registered and verified before sending
+    await DomainService.verifyEmailDomain(fromEmail, projectId);
+
+    // Get project for fallback sender name
+    const project = await prisma.project.findUnique({
+      where: {id: projectId},
+    });
+
+    if (!project) {
+      throw new HttpException(404, 'Project not found');
+    }
+
+    await sendRawEmail({
+      from: {
+        name: fromName || project.name || 'Plunk',
+        email: fromEmail,
+      },
+      to: [testEmail],
+      content: {
+        subject: `[TEST] ${subject}`,
+        html: body,
+      },
+      reply: replyTo || undefined,
+      headers: {
+        'X-Plunk-Test': 'true',
+      },
+      tracking: false,
+    });
   }
 }

--- a/apps/web/src/pages/campaigns/[id].tsx
+++ b/apps/web/src/pages/campaigns/[id].tsx
@@ -196,8 +196,14 @@ export default function CampaignDetailsPage() {
     setDialog({type: 'testEmail', sending: true});
 
     try {
+      // Send what is in the editor right now, so no save is required first.
       await network.fetch<{success: boolean; message: string}>('POST', `/campaigns/${id}/test`, {
         email: testEmailAddress,
+        subject: editedCampaign.subject,
+        body: editedCampaign.body,
+        from: editedCampaign.from,
+        fromName: editedCampaign.fromName || null,
+        replyTo: editedCampaign.replyTo || null,
       } as any);
 
       toast.success(`Test email sent to ${testEmailAddress}`);

--- a/apps/web/src/pages/templates/[id].tsx
+++ b/apps/web/src/pages/templates/[id].tsx
@@ -6,9 +6,21 @@ import {
   CardHeader,
   CardTitle,
   ConfirmDialog,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   IconSpinner,
   Input,
   Label,
+  Select,
+  SelectContent,
+  SelectItem,
+
+  SelectTrigger,
+  SelectValue,
   StickySaveBar,
 } from '@plunk/ui';
 import type {Template} from '@plunk/db';
@@ -17,7 +29,7 @@ import {EmailSettings} from '../../components/EmailSettings';
 import {EmailEditor} from '../../components/EmailEditor';
 import {network} from '../../lib/network';
 import {useChangeTracking} from '../../lib/hooks/useChangeTracking';
-import {ArrowLeft, Save, Trash2, TriangleAlert} from 'lucide-react';
+import {ArrowLeft, Save, Send, Trash2, TriangleAlert} from 'lucide-react';
 import Link from 'next/link';
 import {NextSeo} from 'next-seo';
 import {useRouter} from 'next/router';
@@ -39,6 +51,15 @@ export default function TemplateEditorPage() {
   const [editedTemplate, setEditedTemplate] = useState<Partial<Template>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [isTestEmailDialogOpen, setIsTestEmailDialogOpen] = useState(false);
+  const [testEmailAddress, setTestEmailAddress] = useState('');
+  const [sendingTestEmail, setSendingTestEmail] = useState(false);
+
+  // Fetch project members for test email recipient selection
+  const {data: projectMembers} = useSWR<{data: Array<{userId: string; email: string; role: string}>}>(
+    template?.projectId ? `/projects/${template.projectId}/members` : null,
+    {revalidateOnFocus: false},
+  );
 
   // Initialize edit fields when template loads
   useEffect(() => {
@@ -95,6 +116,29 @@ export default function TemplateEditorPage() {
       toast.error(error instanceof Error ? error.message : 'Failed to save template');
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleSendTestEmail = async () => {
+    if (!testEmailAddress) return;
+    setSendingTestEmail(true);
+    try {
+      // Send what is in the editor right now, so no save is required first.
+      await network.fetch<unknown, never>('POST', `/templates/${id}/test`, {
+        email: testEmailAddress,
+        subject: editedTemplate.subject,
+        body: editedTemplate.body,
+        from: editedTemplate.from,
+        fromName: editedTemplate.fromName || null,
+        replyTo: editedTemplate.replyTo || null,
+      } as Record<string, unknown> as never);
+      toast.success(`Test email sent to ${testEmailAddress}`);
+      setIsTestEmailDialogOpen(false);
+      setTestEmailAddress('');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to send test email');
+    } finally {
+      setSendingTestEmail(false);
     }
   };
 
@@ -281,16 +325,77 @@ export default function TemplateEditorPage() {
               <Trash2 className="h-4 w-4" />
               Delete Template
             </Button>
-            <Button type="submit" disabled={!hasChanges || isSubmitting}>
-              <Save className="h-4 w-4" />
-              {isSubmitting ? 'Saving...' : 'Save Changes'}
-            </Button>
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsTestEmailDialogOpen(true)}
+              >
+                <Send className="h-4 w-4" />
+                <span className="hidden sm:inline">Send Test</span>
+              </Button>
+              <Button type="submit" disabled={!hasChanges || isSubmitting}>
+                <Save className="h-4 w-4" />
+                {isSubmitting ? 'Saving...' : 'Save Changes'}
+              </Button>
+            </div>
           </div>
         </form>
       </div>
 
       {/* Sticky Save Bar */}
       <StickySaveBar status={isSubmitting ? 'saving' : hasChanges ? 'dirty' : 'idle'} onSave={handleSave} />
+
+      {/* Send Test Email Dialog */}
+      <Dialog open={isTestEmailDialogOpen} onOpenChange={setIsTestEmailDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Send Test Email</DialogTitle>
+            <DialogDescription>
+              Send a test version of this template to a project member to verify how it looks. The test email will be
+              prefixed with [TEST] in the subject line.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div>
+              <Label htmlFor="testEmail">Project Member</Label>
+              <Select value={testEmailAddress} onValueChange={setTestEmailAddress}>
+                <SelectTrigger id="testEmail" className="mt-2">
+                  <SelectValue placeholder="Select a project member..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {projectMembers?.data.map(member => (
+                    <SelectItem key={member.userId} value={member.email}>
+                      {member.email}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-neutral-500 mt-2">
+                For security reasons, test emails can only be sent to project members.
+              </p>
+              <p className="text-xs text-neutral-500 mt-1">
+                Note: Variables will not be replaced in test emails. The email will be sent exactly as designed.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setIsTestEmailDialogOpen(false);
+                setTestEmailAddress('');
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSendTestEmail} disabled={sendingTestEmail || !testEmailAddress}>
+              {sendingTestEmail ? 'Sending...' : 'Send Test Email'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Delete Template Confirmation */}
       <ConfirmDialog


### PR DESCRIPTION
## Summary

- Add "Send Test Email" feature for templates, matching the existing campaign test email UI and functionality
- Update both template and campaign test email endpoints to accept optional draft fields (subject, body, from, fromName, replyTo), so test emails reflect the current editor content without requiring a save first

## Changes

**New: Template Send Test Email**
- `apps/api/src/controllers/Templates.ts` — new `POST /templates/:id/test` endpoint
- `apps/api/src/services/TemplateService.ts` — `sendTest()` method with draft content support
- `apps/web/src/pages/templates/[id].tsx` — Send Test button, dialog, and project member selector

**Fix: Use draft content for test emails**
- `apps/api/src/services/CampaignService.ts` — accept optional `draft` param, use draft fields when present
- `apps/api/src/controllers/Campaigns.ts` — pass draft fields from request body to service
- `apps/web/src/pages/campaigns/[id].tsx` — send current editor content with test email request

## Test plan

- [x] Open a template, modify subject/body without saving, send test email → verify test email uses the unsaved content
- [x] Open a campaign, modify subject/body without saving, send test email → verify test email uses the unsaved content
- [x] Send test email without any unsaved changes → verify it still works (falls back to DB content)
- [x] Verify test emails can only be sent to project members

🤖 Generated with [Claude Code](https://claude.com/claude-code)