### PR TITLE
feat: Add option to disable default unsubscribe footer

### DIFF
--- a/apps/api/src/controllers/Campaigns.ts
+++ b/apps/api/src/controllers/Campaigns.ts
@@ -20,8 +20,19 @@ export class Campaigns {
   @CatchAsync
   private async create(req: Request, res: Response, _next: NextFunction) {
     const auth = res.locals.auth;
-    const {name, description, subject, body, from, fromName, replyTo, audienceType, audienceCondition, segmentId} =
-      CampaignSchemas.create.parse(req.body);
+    const {
+      name,
+      description,
+      subject,
+      body,
+      from,
+      fromName,
+      replyTo,
+      audienceType,
+      audienceCondition,
+      segmentId,
+      disableFooter,
+    } = CampaignSchemas.create.parse(req.body);
 
     if (audienceType === CampaignAudienceType.SEGMENT && !segmentId) {
       throw new HttpException(400, 'Segment ID is required for SEGMENT audience type');
@@ -45,6 +56,7 @@ export class Campaigns {
       audienceType,
       audienceCondition,
       segmentId,
+      disableFooter,
     });
 
     return res.status(201).json({
@@ -109,8 +121,19 @@ export class Campaigns {
   private async update(req: Request, res: Response, _next: NextFunction) {
     const auth = res.locals.auth;
     const {id} = UtilitySchemas.id.parse(req.params);
-    const {name, description, subject, body, from, fromName, replyTo, audienceType, audienceCondition, segmentId} =
-      req.body;
+    const {
+      name,
+      description,
+      subject,
+      body,
+      from,
+      fromName,
+      replyTo,
+      audienceType,
+      audienceCondition,
+      segmentId,
+      disableFooter,
+    } = req.body;
 
     // Validate audience-specific fields if audienceType is being updated
     if (audienceType === CampaignAudienceType.SEGMENT && segmentId === undefined) {
@@ -137,6 +160,7 @@ export class Campaigns {
       audienceType,
       audienceCondition,
       segmentId,
+      disableFooter,
     });
 
     return res.json({

--- a/apps/api/src/controllers/Templates.ts
+++ b/apps/api/src/controllers/Templates.ts
@@ -56,7 +56,7 @@ export class Templates {
   @CatchAsync
   public async create(req: Request, res: Response, _next: NextFunction) {
     const auth = res.locals.auth;
-    const {name, description, subject, body, from, fromName, replyTo, type} = req.body;
+    const {name, description, subject, body, from, fromName, replyTo, type, disableFooter} = req.body;
 
     if (!name) {
       return res.status(400).json({error: 'Name is required'});
@@ -86,6 +86,7 @@ export class Templates {
       fromName,
       replyTo,
       type,
+      disableFooter,
     });
 
     return res.status(201).json(template);
@@ -101,7 +102,7 @@ export class Templates {
   public async update(req: Request, res: Response, _next: NextFunction) {
     const auth = res.locals.auth;
     const templateId = req.params.id;
-    const {name, description, subject, body, from, fromName, replyTo, type} = req.body;
+    const {name, description, subject, body, from, fromName, replyTo, type, disableFooter} = req.body;
 
     if (!templateId) {
       return res.status(400).json({error: 'Template ID is required'});
@@ -121,6 +122,7 @@ export class Templates {
       fromName,
       replyTo,
       type,
+      disableFooter,
     });
 
     return res.status(200).json(template);

--- a/apps/api/src/jobs/email-processor.ts
+++ b/apps/api/src/jobs/email-processor.ts
@@ -110,6 +110,7 @@ export async function createEmailWorker() {
           contact: email.contact,
           project: email.project,
           includeUnsubscribe: email.sourceType !== EmailSourceType.TRANSACTIONAL, // Don't add unsubscribe to transactional emails
+          disableFooter: email.disableFooter,
         });
 
         // Use fromName from database if available, otherwise fall back to project name

--- a/apps/api/src/services/CampaignService.ts
+++ b/apps/api/src/services/CampaignService.ts
@@ -48,6 +48,14 @@ export class CampaignService {
       SegmentService.validateCondition(data.audienceCondition);
     }
 
+    // Enforce paid-only gate for disableFooter
+    if (data.disableFooter) {
+      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
+      if (!project?.subscription) {
+        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
+      }
+    }
+
     // Create campaign with initial recipient count of 0
     const campaign = await prisma.campaign.create({
       data: {
@@ -59,6 +67,7 @@ export class CampaignService {
         from: data.from,
         fromName: data.fromName,
         replyTo: data.replyTo,
+        disableFooter: data.disableFooter ?? false,
         audienceType: data.audienceType,
         audienceCondition: toPrismaJson(data.audienceCondition || null),
         segmentId: data.segmentId,
@@ -94,6 +103,14 @@ export class CampaignService {
     // Can only update draft or scheduled campaigns
     if (campaign.status !== CampaignStatus.DRAFT && campaign.status !== CampaignStatus.SCHEDULED) {
       throw new HttpException(400, 'Cannot update campaign that is sending or has been sent');
+    }
+
+    // Enforce paid-only gate for disableFooter
+    if (data.disableFooter) {
+      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
+      if (!project?.subscription) {
+        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
+      }
     }
 
     // Build base update data using shared utility
@@ -262,6 +279,7 @@ export class CampaignService {
         from: campaign.from,
         fromName: campaign.fromName,
         replyTo: campaign.replyTo,
+        disableFooter: campaign.disableFooter,
         audienceType: campaign.audienceType,
         audienceCondition: campaign.audienceCondition as Prisma.InputJsonValue,
         segmentId: campaign.segmentId,
@@ -482,6 +500,7 @@ export class CampaignService {
           from: campaign.from,
           fromName: campaign.fromName || undefined,
           replyTo: campaign.replyTo || undefined,
+          disableFooter: campaign.disableFooter,
         });
       } catch (error) {
         signale.error(`[CAMPAIGN] Failed to queue email for contact ${contact.id}:`, error);

--- a/apps/api/src/services/CampaignService.ts
+++ b/apps/api/src/services/CampaignService.ts
@@ -48,14 +48,6 @@ export class CampaignService {
       SegmentService.validateCondition(data.audienceCondition);
     }
 
-    // Enforce paid-only gate for disableFooter
-    if (data.disableFooter) {
-      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
-      if (!project?.subscription) {
-        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
-      }
-    }
-
     // Create campaign with initial recipient count of 0
     const campaign = await prisma.campaign.create({
       data: {
@@ -103,14 +95,6 @@ export class CampaignService {
     // Can only update draft or scheduled campaigns
     if (campaign.status !== CampaignStatus.DRAFT && campaign.status !== CampaignStatus.SCHEDULED) {
       throw new HttpException(400, 'Cannot update campaign that is sending or has been sent');
-    }
-
-    // Enforce paid-only gate for disableFooter
-    if (data.disableFooter) {
-      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
-      if (!project?.subscription) {
-        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
-      }
     }
 
     // Build base update data using shared utility

--- a/apps/api/src/services/EmailService.ts
+++ b/apps/api/src/services/EmailService.ts
@@ -38,6 +38,7 @@ interface SendEmailParams {
   workflowExecutionId?: string;
   workflowStepExecutionId?: string;
   recipientEmail?: string; // Optional custom recipient email (overrides contact.email)
+  disableFooter?: boolean; // When true, skip the default unsubscribe footer (paid-only feature)
 }
 
 /**
@@ -161,6 +162,7 @@ export class EmailService {
         sourceType,
         templateId: params.templateId,
         campaignId: params.campaignId,
+        disableFooter: params.disableFooter ?? false,
         status: EmailStatus.PENDING,
       },
     });
@@ -267,6 +269,7 @@ export class EmailService {
         templateId: params.templateId,
         workflowExecutionId: params.workflowExecutionId,
         workflowStepExecutionId: params.workflowStepExecutionId,
+        disableFooter: params.disableFooter ?? false,
         status: EmailStatus.PENDING,
       },
     });
@@ -1031,11 +1034,13 @@ export class EmailService {
     contact,
     project,
     includeUnsubscribe = true,
+    disableFooter = false,
   }: {
     content: string;
     contact: Contact;
     project: Project;
     includeUnsubscribe?: boolean;
+    disableFooter?: boolean;
   }): string {
     // Wrap visual editor content with prose styles so the sent email matches the preview modal.
     // Custom HTML (from the HTML editor) already carries its own styles and is used as-is.
@@ -1110,8 +1115,8 @@ export class EmailService {
         </table>`
         : '';
 
-    // Combine footer and badge
-    const footerHtml = `${unsubscribeHtml}${badgeHtml}`;
+    // Combine footer and badge (disableFooter skips the unsubscribe footer but keeps the badge)
+    const footerHtml = disableFooter ? badgeHtml : `${unsubscribeHtml}${badgeHtml}`;
 
     // Insert before closing body tag if it exists, otherwise append
     if (html.includes('</body>')) {

--- a/apps/api/src/services/TemplateService.ts
+++ b/apps/api/src/services/TemplateService.ts
@@ -84,8 +84,17 @@ export class TemplateService {
       fromName?: string | null;
       replyTo?: string | null;
       type?: Template['type'];
+      disableFooter?: boolean;
     },
   ): Promise<Template> {
+    // Enforce paid-only gate for disableFooter
+    if (data.disableFooter) {
+      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
+      if (!project?.subscription) {
+        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
+      }
+    }
+
     return prisma.template.create({
       data: {
         projectId,
@@ -97,6 +106,7 @@ export class TemplateService {
         fromName: data.fromName,
         replyTo: data.replyTo,
         type: data.type ?? 'MARKETING',
+        disableFooter: data.disableFooter ?? false,
       },
     });
   }
@@ -116,10 +126,19 @@ export class TemplateService {
       fromName?: string | null;
       replyTo?: string | null;
       type?: Template['type'];
+      disableFooter?: boolean;
     },
   ): Promise<Template> {
     // Verify template exists and belongs to project
     await this.get(projectId, templateId);
+
+    // Enforce paid-only gate for disableFooter
+    if (data.disableFooter) {
+      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
+      if (!project?.subscription) {
+        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
+      }
+    }
 
     const updateData = {
       ...buildEmailFieldsUpdate(data),
@@ -177,6 +196,7 @@ export class TemplateService {
         fromName: template.fromName,
         replyTo: template.replyTo,
         type: template.type,
+        disableFooter: template.disableFooter,
       },
     });
   }

--- a/apps/api/src/services/TemplateService.ts
+++ b/apps/api/src/services/TemplateService.ts
@@ -87,14 +87,6 @@ export class TemplateService {
       disableFooter?: boolean;
     },
   ): Promise<Template> {
-    // Enforce paid-only gate for disableFooter
-    if (data.disableFooter) {
-      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
-      if (!project?.subscription) {
-        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
-      }
-    }
-
     return prisma.template.create({
       data: {
         projectId,
@@ -131,14 +123,6 @@ export class TemplateService {
   ): Promise<Template> {
     // Verify template exists and belongs to project
     await this.get(projectId, templateId);
-
-    // Enforce paid-only gate for disableFooter
-    if (data.disableFooter) {
-      const project = await prisma.project.findUnique({where: {id: projectId}, select: {subscription: true}});
-      if (!project?.subscription) {
-        throw new HttpException(403, 'Disabling the footer is only available for projects with an active subscription');
-      }
-    }
 
     const updateData = {
       ...buildEmailFieldsUpdate(data),

--- a/apps/api/src/services/WorkflowExecutionService.ts
+++ b/apps/api/src/services/WorkflowExecutionService.ts
@@ -580,6 +580,7 @@ export class WorkflowExecutionService {
       replyTo: step.template.replyTo || undefined,
       // Pass custom recipient email if specified
       recipientEmail: recipientConfig.type === 'CUSTOM' ? recipientConfig.customEmail : undefined,
+      disableFooter: step.template.disableFooter,
     });
 
     return {

--- a/apps/api/src/utils/modelUpdate.ts
+++ b/apps/api/src/utils/modelUpdate.ts
@@ -36,6 +36,7 @@ export function buildEmailFieldsUpdate(data: {
   from?: string;
   fromName?: string | null;
   replyTo?: string | null;
+  disableFooter?: boolean;
 }): Prisma.CampaignUpdateInput | Prisma.TemplateUpdateInput {
   return buildUpdateData(data) as Prisma.CampaignUpdateInput | Prisma.TemplateUpdateInput;
 }

--- a/apps/web/src/pages/campaigns/[id].tsx
+++ b/apps/web/src/pages/campaigns/[id].tsx
@@ -27,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
   StickySaveBar,
+  Switch,
 } from '@plunk/ui';
 import type {Campaign, Segment} from '@plunk/db';
 import {CampaignAudienceType, CampaignStatus} from '@plunk/db';
@@ -218,6 +219,7 @@ export default function CampaignDetailsPage() {
         replyTo: editedCampaign.replyTo || null,
         audienceType: editedCampaign.audienceType,
         segmentId: editedCampaign.segmentId || undefined,
+        disableFooter: editedCampaign.disableFooter,
       });
       // Silent save - no toast notification
       setHasChanges(false);
@@ -234,6 +236,7 @@ export default function CampaignDetailsPage() {
           replyTo: updated.data.replyTo || '',
           audienceType: updated.data.audienceType,
           segmentId: updated.data.segmentId || undefined,
+          disableFooter: updated.data.disableFooter,
         });
       }
     } catch (error) {
@@ -256,6 +259,7 @@ export default function CampaignDetailsPage() {
         replyTo: campaign.data.replyTo || '',
         audienceType: campaign.data.audienceType,
         segmentId: campaign.data.segmentId || undefined,
+        disableFooter: campaign.data.disableFooter,
       });
       // Reset hasChanges when loading fresh data
       setHasChanges(false);
@@ -275,7 +279,8 @@ export default function CampaignDetailsPage() {
       (editedCampaign.fromName || '') !== (campaign.data.fromName || '') ||
       (editedCampaign.replyTo || '') !== (campaign.data.replyTo || '') ||
       editedCampaign.audienceType !== campaign.data.audienceType ||
-      (editedCampaign.segmentId || null) !== (campaign.data.segmentId || null);
+      (editedCampaign.segmentId || null) !== (campaign.data.segmentId || null) ||
+      editedCampaign.disableFooter !== campaign.data.disableFooter;
 
     setHasChanges(changed);
   }, [editedCampaign, campaign]);
@@ -484,6 +489,23 @@ export default function CampaignDetailsPage() {
                   showFromNameHelpText
                   layout="vertical"
                 />
+
+                {activeProject?.subscription && (
+                  <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="disableFooter">Disable default footer</Label>
+                      <p className="text-xs text-neutral-500">
+                        When enabled, the default unsubscribe footer will not be appended. You are responsible for
+                        including your own unsubscribe mechanism.
+                      </p>
+                    </div>
+                    <Switch
+                      id="disableFooter"
+                      checked={editedCampaign.disableFooter ?? false}
+                      onCheckedChange={checked => setEditedCampaign({...editedCampaign, disableFooter: checked})}
+                    />
+                  </div>
+                )}
               </CardContent>
             </Card>
 

--- a/apps/web/src/pages/campaigns/[id].tsx
+++ b/apps/web/src/pages/campaigns/[id].tsx
@@ -490,22 +490,20 @@ export default function CampaignDetailsPage() {
                   layout="vertical"
                 />
 
-                {activeProject?.subscription && (
-                  <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
-                    <div className="space-y-0.5">
-                      <Label htmlFor="disableFooter">Disable default footer</Label>
-                      <p className="text-xs text-neutral-500">
-                        When enabled, the default unsubscribe footer will not be appended. You are responsible for
-                        including your own unsubscribe mechanism.
-                      </p>
-                    </div>
-                    <Switch
-                      id="disableFooter"
-                      checked={editedCampaign.disableFooter ?? false}
-                      onCheckedChange={checked => setEditedCampaign({...editedCampaign, disableFooter: checked})}
-                    />
+                <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="disableFooter">Disable default footer</Label>
+                    <p className="text-xs text-neutral-500">
+                      When enabled, the default unsubscribe footer will not be appended. You are responsible for
+                      including your own unsubscribe mechanism.
+                    </p>
                   </div>
-                )}
+                  <Switch
+                    id="disableFooter"
+                    checked={editedCampaign.disableFooter ?? false}
+                    onCheckedChange={checked => setEditedCampaign({...editedCampaign, disableFooter: checked})}
+                  />
+                </div>
               </CardContent>
             </Card>
 

--- a/apps/web/src/pages/campaigns/create.tsx
+++ b/apps/web/src/pages/campaigns/create.tsx
@@ -12,6 +12,7 @@ import {
   SelectItemWithDescription,
   SelectTrigger,
   SelectValue,
+  Switch,
   Textarea,
 } from '@plunk/ui';
 import type {Segment, Template} from '@plunk/db';
@@ -43,6 +44,7 @@ export default function CreateCampaignPage() {
   const [replyTo, setReplyTo] = useState('');
   const [audienceType, setAudienceType] = useState<CampaignAudienceType>(CampaignAudienceType.ALL);
   const [segmentId, setSegmentId] = useState('');
+  const [disableFooter, setDisableFooter] = useState(false);
   const [saving, setSaving] = useState(false);
   const [loadingTemplate, setLoadingTemplate] = useState(false);
 
@@ -153,6 +155,7 @@ export default function CreateCampaignPage() {
         audienceType,
         segmentId: audienceType === CampaignAudienceType.SEGMENT ? segmentId : undefined,
         audienceFilter: audienceType === CampaignAudienceType.FILTERED ? [] : undefined,
+        disableFooter,
       } as any);
 
       toast.success('Campaign created successfully');
@@ -288,6 +291,23 @@ export default function CreateCampaignPage() {
                         required
                       />
                     </div>
+
+                    {activeProject?.subscription && (
+                      <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
+                        <div className="space-y-0.5">
+                          <Label htmlFor="disableFooter">Disable default footer</Label>
+                          <p className="text-xs text-neutral-500">
+                            When enabled, the default unsubscribe footer will not be appended. You are responsible for
+                            including your own unsubscribe mechanism.
+                          </p>
+                        </div>
+                        <Switch
+                          id="disableFooter"
+                          checked={disableFooter}
+                          onCheckedChange={setDisableFooter}
+                        />
+                      </div>
+                    )}
                   </CardContent>
                 </Card>
 

--- a/apps/web/src/pages/campaigns/create.tsx
+++ b/apps/web/src/pages/campaigns/create.tsx
@@ -292,22 +292,20 @@ export default function CreateCampaignPage() {
                       />
                     </div>
 
-                    {activeProject?.subscription && (
-                      <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
-                        <div className="space-y-0.5">
-                          <Label htmlFor="disableFooter">Disable default footer</Label>
-                          <p className="text-xs text-neutral-500">
-                            When enabled, the default unsubscribe footer will not be appended. You are responsible for
-                            including your own unsubscribe mechanism.
-                          </p>
-                        </div>
-                        <Switch
-                          id="disableFooter"
-                          checked={disableFooter}
-                          onCheckedChange={setDisableFooter}
-                        />
+                    <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
+                      <div className="space-y-0.5">
+                        <Label htmlFor="disableFooter">Disable default footer</Label>
+                        <p className="text-xs text-neutral-500">
+                          When enabled, the default unsubscribe footer will not be appended. You are responsible for
+                          including your own unsubscribe mechanism.
+                        </p>
                       </div>
-                    )}
+                      <Switch
+                        id="disableFooter"
+                        checked={disableFooter}
+                        onCheckedChange={setDisableFooter}
+                      />
+                    </div>
                   </CardContent>
                 </Card>
 

--- a/apps/web/src/pages/templates/[id].tsx
+++ b/apps/web/src/pages/templates/[id].tsx
@@ -253,7 +253,7 @@ export default function TemplateEditorPage() {
                   </p>
                 </div>
 
-                {editedTemplate.type === 'MARKETING' && activeProject?.subscription && (
+                {editedTemplate.type === 'MARKETING' && (
                   <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
                     <div className="space-y-0.5">
                       <Label htmlFor="disableFooter">Disable default footer</Label>

--- a/apps/web/src/pages/templates/[id].tsx
+++ b/apps/web/src/pages/templates/[id].tsx
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
   StickySaveBar,
+  Switch,
 } from '@plunk/ui';
 import type {Template} from '@plunk/db';
 import {DashboardLayout} from '../../components/DashboardLayout';
@@ -56,6 +57,7 @@ export default function TemplateEditorPage() {
         fromName: template.fromName || '',
         replyTo: template.replyTo || '',
         type: template.type,
+        disableFooter: template.disableFooter,
       });
       // Reset hasChanges when loading fresh data
       setHasChanges(false);
@@ -74,7 +76,8 @@ export default function TemplateEditorPage() {
       editedTemplate.from !== template.from ||
       (editedTemplate.fromName || '') !== (template.fromName || '') ||
       (editedTemplate.replyTo || '') !== (template.replyTo || '') ||
-      editedTemplate.type !== template.type;
+      editedTemplate.type !== template.type ||
+      editedTemplate.disableFooter !== template.disableFooter;
 
     setHasChanges(changed);
   }, [editedTemplate, template]);
@@ -96,6 +99,7 @@ export default function TemplateEditorPage() {
         fromName: editedTemplate.fromName || null,
         replyTo: editedTemplate.replyTo || null,
         type: editedTemplate.type,
+        disableFooter: editedTemplate.disableFooter,
       });
 
       // Silent save - no toast notification
@@ -248,6 +252,23 @@ export default function TemplateEditorPage() {
                     Marketing templates will automatically include a Plunk-hosted unsubscribe link.
                   </p>
                 </div>
+
+                {editedTemplate.type === 'MARKETING' && activeProject?.subscription && (
+                  <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="disableFooter">Disable default footer</Label>
+                      <p className="text-xs text-neutral-500">
+                        When enabled, the default unsubscribe footer will not be appended. You are responsible for
+                        including your own unsubscribe mechanism.
+                      </p>
+                    </div>
+                    <Switch
+                      id="disableFooter"
+                      checked={editedTemplate.disableFooter ?? false}
+                      onCheckedChange={checked => setEditedTemplate({...editedTemplate, disableFooter: checked})}
+                    />
+                  </div>
+                )}
 
                 <div>
                   <Label htmlFor="subject">Subject Line *</Label>

--- a/apps/web/src/pages/templates/create.tsx
+++ b/apps/web/src/pages/templates/create.tsx
@@ -12,6 +12,7 @@ import {
   SelectItemWithDescription,
   SelectTrigger,
   SelectValue,
+  Switch,
 } from '@plunk/ui';
 import {NextSeo} from 'next-seo';
 import {DashboardLayout} from '../../components/DashboardLayout';
@@ -38,6 +39,7 @@ export default function CreateTemplatePage() {
   const [fromName, setFromName] = useState('');
   const [replyTo, setReplyTo] = useState('');
   const [type, setType] = useState<'MARKETING' | 'TRANSACTIONAL'>('MARKETING');
+  const [disableFooter, setDisableFooter] = useState(false);
   const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -61,6 +63,7 @@ export default function CreateTemplatePage() {
         fromName: fromName || null,
         replyTo: replyTo || null,
         type,
+        disableFooter,
       });
 
       toast.success('Template created successfully');
@@ -142,6 +145,23 @@ export default function CreateTemplatePage() {
                     </Select>
                   </div>
                 </div>
+
+                {type === 'MARKETING' && activeProject?.subscription && (
+                  <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4 md:col-span-2">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="disableFooter">Disable default footer</Label>
+                      <p className="text-xs text-neutral-500">
+                        When enabled, the default unsubscribe footer will not be appended. You are responsible for
+                        including your own unsubscribe mechanism.
+                      </p>
+                    </div>
+                    <Switch
+                      id="disableFooter"
+                      checked={disableFooter}
+                      onCheckedChange={setDisableFooter}
+                    />
+                  </div>
+                )}
 
                 <div>
                   <Label htmlFor="description">Description</Label>

--- a/apps/web/src/pages/templates/create.tsx
+++ b/apps/web/src/pages/templates/create.tsx
@@ -146,7 +146,7 @@ export default function CreateTemplatePage() {
                   </div>
                 </div>
 
-                {type === 'MARKETING' && activeProject?.subscription && (
+                {type === 'MARKETING' && (
                   <div className="flex items-center justify-between rounded-lg border border-neutral-200 p-4 md:col-span-2">
                     <div className="space-y-0.5">
                       <Label htmlFor="disableFooter">Disable default footer</Label>

--- a/packages/db/prisma/migrations/20260324194617_add_disable_footer/migration.sql
+++ b/packages/db/prisma/migrations/20260324194617_add_disable_footer/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "campaigns" ADD COLUMN     "disableFooter" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "emails" ADD COLUMN     "disableFooter" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "templates" ADD COLUMN     "disableFooter" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -169,6 +169,9 @@ model Template {
   fromName String?
   replyTo  String?
 
+  // Footer control (paid-only feature)
+  disableFooter Boolean @default(false)
+
   // Type
   type TemplateType @default(MARKETING)
 
@@ -290,6 +293,9 @@ model Campaign {
   from     String
   fromName String?
   replyTo  String?
+
+  // Footer control (paid-only feature)
+  disableFooter Boolean @default(false)
 
   // Audience selection
   audienceType      CampaignAudienceType @default(ALL)
@@ -526,6 +532,9 @@ model Email {
   replyTo     String?
   headers     Json? // Custom email headers
   attachments Json? // Array of {filename: string, content: string (base64), contentType: string}
+
+  // Footer control
+  disableFooter Boolean @default(false)
 
   // AWS SES Message ID (for tracking webhooks)
   messageId String? @unique

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -158,6 +158,7 @@ export const TemplateSchemas = {
     fromName: z.string().max(100).nullish(),
     replyTo: email.nullish(),
     type: z.nativeEnum(TemplateType).default('MARKETING'),
+    disableFooter: z.boolean().default(false),
   }),
   update: z.object({
     name: z.string().min(1).max(100).optional(),
@@ -168,6 +169,7 @@ export const TemplateSchemas = {
     fromName: z.string().max(100).nullish(),
     replyTo: email.nullish(),
     type: z.nativeEnum(TemplateType).optional(),
+    disableFooter: z.boolean().optional(),
   }),
 };
 
@@ -352,6 +354,7 @@ export const CampaignSchemas = {
     audienceType: z.nativeEnum(CampaignAudienceType),
     audienceCondition: filterConditionSchema.optional(),
     segmentId: uuid.optional(),
+    disableFooter: z.boolean().default(false),
   }),
   schedule: z.object({
     scheduledFor: z.string(),
@@ -367,6 +370,7 @@ export const CampaignSchemas = {
     audienceType: z.nativeEnum(CampaignAudienceType).optional(),
     audienceCondition: filterConditionSchema.optional(),
     segmentId: z.string().optional(),
+    disableFooter: z.boolean().optional(),
   }),
   sendTest: z.object({
     email,

--- a/packages/types/src/api/campaign.ts
+++ b/packages/types/src/api/campaign.ts
@@ -19,6 +19,7 @@ export interface CreateCampaignData {
   audienceType: CampaignAudienceType;
   audienceCondition?: FilterCondition;
   segmentId?: string;
+  disableFooter?: boolean;
 }
 
 /**
@@ -35,4 +36,5 @@ export interface UpdateCampaignData {
   audienceType?: CampaignAudienceType;
   audienceCondition?: FilterCondition;
   segmentId?: string;
+  disableFooter?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds a `disableFooter` toggle to campaigns and templates, allowing any project to opt out of the auto-appended unsubscribe footer (Closes #322)
- Flag is threaded end-to-end: schema → validation → API controllers/services → Email record → BullMQ worker → `EmailService.compile()`
- Toggle is available to all projects, including self-hosted deployments

## Changes
- **Database**: `disableFooter` boolean added to Campaign, Template, and Email models (default `false`), with Prisma migration included
- **Email pipeline**: `compile()` skips the unsubscribe footer when `disableFooter` is true; Plunk badge logic is unaffected
- **API**: Controllers and services for campaigns and templates accept and propagate `disableFooter` through create, update, and duplicate flows
- **UI**: Switch toggle shown in campaign create/edit and template create/edit pages (templates: only for MARKETING type)

## Test plan
- [ ] Run Prisma migration (`yarn workspace @plunk/db migrate:dev`)
- [ ] Create campaign with `disableFooter: true` — verify no footer in sent email
- [ ] Verify existing campaigns/templates are unaffected (footer enabled by default)
- [ ] Verify toggle is visible for all projects (including self-hosted with no Stripe)
- [ ] Verify template toggle only appears for MARKETING type
- [ ] Verify workflow emails respect the template's `disableFooter` setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)