### PR TITLE
fix: Adapt SNS Webhook validation regex pattern to also support AWS eusc partition

### DIFF
--- a/apps/api/src/controllers/Webhooks.ts
+++ b/apps/api/src/controllers/Webhooks.ts
@@ -53,8 +53,8 @@ export class Webhooks {
         }
 
         // Only allow HTTPS requests to official AWS SNS endpoints.
-        // The hostname must be exactly sns.<region>.amazonaws.com.
-        const SNS_HOST_RE = /^sns\.[a-z0-9-]+\.amazonaws\.com$/;
+        // The hostname must be exactly sns.<region>.amazonaws.com or sns.<region>.amazonaws.eu
+        const SNS_HOST_RE = /^sns\.[a-z0-9-]+\.amazonaws\.(com|eu)$/;
         if (parsedURL.protocol !== 'https:' || !SNS_HOST_RE.test(parsedURL.hostname)) {
           signale.warn(`SNS SubscriptionConfirmation rejected — disallowed SubscribeURL host: ${parsedURL.hostname}`);
           return res.status(400).json({success: false, message: 'Invalid SubscribeURL'});


### PR DESCRIPTION
## Description

The SNS webhook host validation introduced in https://github.com/useplunk/plunk/commit/b8f1ad9ab53c78f8ef063fdc125f397c8bfc7652 does not support the AWS EUSC partition. This PR adapts the regex pattern to also support "sns.eusc-de-east-1.amazonaws.eu" as a valid SNS webhook host.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [ ] `feat:` New feature (MINOR version bump)
- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Testing

Tested the regex pattern with valid and invalid SNS host names.

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)
