### PR TITLE
fix: Handle dots in custom field names for segments, workflows, and templates

### DIFF
--- a/apps/api/src/services/SegmentService.ts
+++ b/apps/api/src/services/SegmentService.ts
@@ -818,7 +818,10 @@ export class SegmentService {
     value: unknown,
     unit?: 'days' | 'hours' | 'minutes',
   ): Prisma.ContactWhereInput {
-    const path = jsonPath.split('.');
+    // Use the entire jsonPath as a single path element.
+    // Contact data is a flat JSON object, so field names like "prefix.key"
+    // must be treated as literal keys, not nested paths.
+    const path = [jsonPath];
 
     switch (operator) {
       case 'equals':

--- a/apps/api/src/services/WorkflowExecutionService.ts
+++ b/apps/api/src/services/WorkflowExecutionService.ts
@@ -1111,7 +1111,15 @@ export class WorkflowExecutionService {
       normalizedField = field.substring(8); // Remove "contact." prefix, leaving "data.X"
     }
 
-    const parts = normalizedField.split('.');
+    // Split only on the first dot to separate the top-level field (e.g., "data")
+    // from the custom field name. This preserves dots in custom field names
+    // (e.g., "data.prefix.key" → ["data", "prefix.key"]).
+    const firstDotIndex = normalizedField.indexOf('.');
+    const parts =
+      firstDotIndex === -1
+        ? [normalizedField]
+        : [normalizedField.substring(0, firstDotIndex), normalizedField.substring(firstDotIndex + 1)];
+
     let value: unknown = data;
 
     for (const part of parts) {

--- a/packages/shared/src/template.ts
+++ b/packages/shared/src/template.ts
@@ -13,13 +13,24 @@ export function renderTemplate(template: string, variables: Record<string, unkno
     const [mainKey, defaultValue] = key.split('??').map((s: string) => s.trim());
 
     // Handle nested property access (e.g., data.firstName)
+    // Uses recursive first-dot splitting so that literal dots in custom field
+    // names (e.g., "prefix.key") are resolved correctly: direct key lookup is
+    // tried before descending into nested objects.
     const getValue = (obj: Record<string, unknown>, path: string): unknown => {
-      return path.split('.').reduce((current: Record<string, unknown> | unknown, key) => {
-        if (current && typeof current === 'object' && !Array.isArray(current)) {
-          return (current as Record<string, unknown>)[key];
-        }
+      if (path in obj) {
+        return obj[path];
+      }
+      const firstDotIndex = path.indexOf('.');
+      if (firstDotIndex === -1) {
         return undefined;
-      }, obj);
+      }
+      const firstKey = path.substring(0, firstDotIndex);
+      const rest = path.substring(firstDotIndex + 1);
+      const next = obj[firstKey];
+      if (next && typeof next === 'object' && !Array.isArray(next)) {
+        return getValue(next as Record<string, unknown>, rest);
+      }
+      return undefined;
     };
 
     // Try multiple lookup strategies


### PR DESCRIPTION
## Summary

- Custom fields with dots in their names (e.g., `prefix.key`) were silently broken across segment filtering, workflow conditions, and email template rendering because the code split on `.` to build path lookups, treating them as nested JSON paths instead of literal flat keys
- Fixes `SegmentService`, `WorkflowExecutionService`, and `template.ts` to preserve dots in custom field names
- Backwards-compatible: fields without dots continue to work identically

Fixes #346

## Changes

**`SegmentService.buildJsonFieldCondition`** — Use `[jsonPath]` (single-element array) instead of `jsonPath.split('.')`. Contact data is always a flat JSON object, so the Prisma JSON path should always be a single key.

**`WorkflowExecutionService.resolveField`** — Split only on the first `.` to separate the top-level field name (`data`) from the custom field name (`prefix.key`), instead of splitting on every `.`.

**`template.ts` `getValue`** — Replace `split('.').reduce()` with a recursive function that tries direct key lookup at each level before descending via dot-splitting. For `data.prefix.key`, it enters `data`, then finds `prefix.key` as a literal key.

## Test plan

- [ ] Verify dynamic segments match contacts with dotted custom field names (e.g., `data.app.plan`)
- [ ] Verify workflow CONDITION steps correctly evaluate dotted custom fields
- [ ] Verify email templates render `{{data.prefix.key}}` correctly
- [ ] Verify existing non-dotted fields (`data.plan`, `data.firstName`) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)