### PR TITLE
fix: increase workflow template dropdown cap (100 limit) with debounced search

### DIFF
--- a/apps/web/src/components/TemplateSearchPicker.tsx
+++ b/apps/web/src/components/TemplateSearchPicker.tsx
@@ -20,14 +20,13 @@ interface TemplateSearchPickerProps {
  */
 export function TemplateSearchPicker({value, initialName, onChange}: TemplateSearchPickerProps) {
   const [query, setQuery] = useState(initialName ?? '');
+  const [prevInitialName, setPrevInitialName] = useState(initialName);
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [open, setOpen] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const prevInitialName = useRef(initialName);
 
-  // Sync display name when initialName changes (e.g. dialog re-opens with a different selection)
-  if (initialName !== prevInitialName.current) {
-    prevInitialName.current = initialName;
+  if (initialName !== prevInitialName) {
+    setPrevInitialName(initialName);
     setQuery(initialName ?? '');
   }
 

--- a/apps/web/src/components/TemplateSearchPicker.tsx
+++ b/apps/web/src/components/TemplateSearchPicker.tsx
@@ -2,7 +2,7 @@ import {Input} from '@plunk/ui';
 import type {Template} from '@plunk/db';
 import type {PaginatedResponse} from '@plunk/types';
 import {Command, CommandGroup, CommandItem, CommandList} from '@plunk/ui';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import useSWR from 'swr';
 
 interface TemplateSearchPickerProps {
@@ -23,11 +23,13 @@ export function TemplateSearchPicker({value, initialName, onChange}: TemplateSea
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [open, setOpen] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevInitialName = useRef(initialName);
 
-  // When the dialog re-opens with an existing selection, sync the display name
-  useEffect(() => {
+  // Sync display name when initialName changes (e.g. dialog re-opens with a different selection)
+  if (initialName !== prevInitialName.current) {
+    prevInitialName.current = initialName;
     setQuery(initialName ?? '');
-  }, [initialName]);
+  }
 
   const handleInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;

--- a/apps/web/src/components/TemplateSearchPicker.tsx
+++ b/apps/web/src/components/TemplateSearchPicker.tsx
@@ -1,0 +1,104 @@
+import {Input} from '@plunk/ui';
+import type {Template} from '@plunk/db';
+import type {PaginatedResponse} from '@plunk/types';
+import {Command, CommandGroup, CommandItem, CommandList} from '@plunk/ui';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import useSWR from 'swr';
+
+interface TemplateSearchPickerProps {
+  /** Currently selected template ID */
+  value: string;
+  /** Display name for the pre-selected template (avoids a fetch just to show the name) */
+  initialName?: string;
+  onChange: (id: string) => void;
+}
+
+/**
+ * Inline combobox for picking a template.
+ * Fires a debounced server-side search (/templates?search=…&pageSize=20)
+ * so it works correctly regardless of how many templates exist.
+ */
+export function TemplateSearchPicker({value, initialName, onChange}: TemplateSearchPickerProps) {
+  const [query, setQuery] = useState(initialName ?? '');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // When the dialog re-opens with an existing selection, sync the display name
+  useEffect(() => {
+    setQuery(initialName ?? '');
+  }, [initialName]);
+
+  const handleInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setQuery(val);
+    setOpen(true);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebouncedQuery(val), 300);
+  }, []);
+
+  const {data, isLoading} = useSWR<PaginatedResponse<Template>>(
+    open || debouncedQuery
+      ? `/templates?pageSize=20${debouncedQuery ? `&search=${encodeURIComponent(debouncedQuery)}` : ''}`
+      : null,
+    {revalidateOnFocus: false},
+  );
+
+  // When closed, show the selected template's name rather than the raw query
+  const displayValue = open
+    ? query
+    : (value ? (data?.data.find(t => t.id === value)?.name ?? initialName ?? value) : '');
+
+  return (
+    <div className="relative">
+      <Input
+        type="text"
+        value={displayValue}
+        onChange={handleInput}
+        onFocus={() => {
+          setOpen(true);
+          setDebouncedQuery(query);
+        }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder="Search templates…"
+        autoComplete="off"
+      />
+
+      {open && (
+        <div className="absolute z-50 w-full mt-1 rounded-md border border-neutral-200 bg-white shadow-md max-h-60 overflow-y-auto">
+          {isLoading ? (
+            <div className="px-3 py-2 text-sm text-neutral-500">Searching…</div>
+          ) : !data?.data.length ? (
+            <div className="px-3 py-2 text-sm text-neutral-500">No templates found</div>
+          ) : (
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {data.data.map(t => (
+                    <CommandItem
+                      key={t.id}
+                      value={t.id}
+                      onSelect={() => {
+                        onChange(t.id);
+                        setQuery(t.name);
+                        setOpen(false);
+                      }}
+                    >
+                      <span className="flex-1 truncate">{t.name}</span>
+                      <span className="ml-2 text-xs text-neutral-400 shrink-0">{t.type}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          )}
+          {(data?.total ?? 0) > 20 && (
+            <div className="px-3 py-1.5 text-xs text-neutral-400 border-t border-neutral-100">
+              Showing 20 of {data!.total} — type to narrow results
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/workflows/[id].tsx
+++ b/apps/web/src/pages/workflows/[id].tsx
@@ -56,7 +56,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {toast} from 'sonner';
 import useSWR from 'swr';
 import {WorkflowBuilder} from '../../components/WorkflowBuilder';
@@ -1004,7 +1004,7 @@ function AddStepDialog({open, onOpenChange, workflowId, onSuccess}: AddStepDialo
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const {data: templatesData} = useSWR<PaginatedResponse<Template>>('/templates?pageSize=100');
+  // templates fetched on-demand by TemplateSearchPicker
   const {data: workflow} = useSWR<WorkflowWithDetails>(workflowId ? `/workflows/${workflowId}` : null);
 
   // Fetch available event names when dialog opens
@@ -1340,21 +1340,7 @@ function AddStepDialog({open, onOpenChange, workflowId, onSuccess}: AddStepDialo
                   <Label htmlFor="template" className="text-sm font-medium">
                     Email Template *
                   </Label>
-                  <Select value={templateId} onValueChange={setTemplateId} required>
-                    <SelectTrigger id="template" className="mt-1.5">
-                      <SelectValue placeholder="Select a template..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {templatesData?.data.map(template => (
-                        <SelectItemWithDescription
-                          key={template.id}
-                          value={template.id}
-                          title={template.name}
-                          description={`${template.type === 'TRANSACTIONAL' ? 'Transactional' : 'Marketing'} • Subject: ${template.subject}`}
-                        />
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <TemplateSearchPicker value={templateId} onChange={setTemplateId} />
                   <p className="text-xs text-neutral-500 mt-1.5">The email template to use for this step</p>
                 </div>
 
@@ -1872,6 +1858,93 @@ function AddStepDialog({open, onOpenChange, workflowId, onSuccess}: AddStepDialo
   );
 }
 
+// TemplateSearchPicker — server-side debounced search, replaces the static <Select> for templates
+interface TemplateSearchPickerProps {
+  value: string;               // selected template ID
+  initialName?: string;        // display name for the currently-selected template (pre-fill input)
+  onChange: (id: string) => void;
+}
+
+function TemplateSearchPicker({value, initialName, onChange}: TemplateSearchPickerProps) {
+  const [query, setQuery] = useState(initialName ?? '');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync display name when dialog re-opens with an existing selection
+  useEffect(() => {
+    setQuery(initialName ?? '');
+  }, [initialName]);
+
+  const handleInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setQuery(val);
+    setOpen(true);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => setDebouncedQuery(val), 300);
+  }, []);
+
+  const {data, isLoading} = useSWR<PaginatedResponse<Template>>(
+    open || debouncedQuery
+      ? `/templates?pageSize=20${debouncedQuery ? `&search=${encodeURIComponent(debouncedQuery)}` : ''}`
+      : null,
+    {revalidateOnFocus: false},
+  );
+
+  const selectedName = value
+    ? (data?.data.find(t => t.id === value)?.name ?? initialName ?? value)
+    : '';
+
+  return (
+    <div className="relative">
+      <Input
+        type="text"
+        value={open ? query : selectedName}
+        onChange={handleInput}
+        onFocus={() => { setOpen(true); setDebouncedQuery(query); }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+        placeholder="Search templates…"
+        autoComplete="off"
+      />
+      {open && (
+        <div className="absolute z-50 w-full mt-1 rounded-md border border-neutral-200 bg-white shadow-md max-h-60 overflow-y-auto">
+          {isLoading ? (
+            <div className="px-3 py-2 text-sm text-neutral-500">Searching…</div>
+          ) : !data?.data.length ? (
+            <div className="px-3 py-2 text-sm text-neutral-500">No templates found</div>
+          ) : (
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {data.data.map(t => (
+                    <CommandItem
+                      key={t.id}
+                      value={t.id}
+                      onSelect={() => {
+                        onChange(t.id);
+                        setQuery(t.name);
+                        setOpen(false);
+                      }}
+                    >
+                      <span className="flex-1 truncate">{t.name}</span>
+                      <span className="ml-2 text-xs text-neutral-400 shrink-0">{t.type}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          )}
+          {(data?.total ?? 0) > 20 && (
+            <div className="px-3 py-1.5 text-xs text-neutral-400 border-t border-neutral-100">
+              Showing 20 of {data!.total} — type to narrow results
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // Edit Step Dialog Component
 interface EditStepDialogProps {
   step: WorkflowStep & {template?: {id: string; name: string} | null};
@@ -2073,7 +2146,7 @@ function EditStepDialog({step, workflowId, open, onOpenChange, onSuccess}: EditS
   // EXIT fields
   const [exitReason, setExitReason] = useState(String(config?.reason || 'completed'));
 
-  const {data: templatesData} = useSWR<PaginatedResponse<Template>>('/templates?pageSize=100');
+  // templates fetched on-demand by TemplateSearchPicker
   const {data: workflow} = useSWR<WorkflowWithDetails>(workflowId ? `/workflows/${workflowId}` : null);
 
   // Fetch available event names when dialog opens
@@ -2359,21 +2432,7 @@ function EditStepDialog({step, workflowId, open, onOpenChange, onSuccess}: EditS
                   <Label htmlFor="editTemplate" className="text-sm font-medium">
                     Email Template *
                   </Label>
-                  <Select value={templateId} onValueChange={setTemplateId} required>
-                    <SelectTrigger id="editTemplate" className="mt-1.5">
-                      <SelectValue placeholder="Select a template..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {templatesData?.data.map(template => (
-                        <SelectItemWithDescription
-                          key={template.id}
-                          value={template.id}
-                          title={template.name}
-                          description={`${template.type === 'TRANSACTIONAL' ? 'Transactional' : 'Marketing'} • Subject: ${template.subject}`}
-                        />
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <TemplateSearchPicker value={templateId} initialName={step.template?.name} onChange={setTemplateId} />
                   <p className="text-xs text-neutral-500 mt-1.5">The email template to use for this step</p>
                 </div>
 

--- a/apps/web/src/pages/workflows/[id].tsx
+++ b/apps/web/src/pages/workflows/[id].tsx
@@ -56,10 +56,11 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {toast} from 'sonner';
 import useSWR from 'swr';
 import {WorkflowBuilder} from '../../components/WorkflowBuilder';
+import {TemplateSearchPicker} from '../../components/TemplateSearchPicker';
 import {ReactFlowProvider} from '@xyflow/react';
 import {WorkflowSchemas} from '@plunk/shared';
 import dayjs from 'dayjs';
@@ -1855,93 +1856,6 @@ function AddStepDialog({open, onOpenChange, workflowId, onSuccess}: AddStepDialo
         </form>
       </DialogContent>
     </Dialog>
-  );
-}
-
-// TemplateSearchPicker — server-side debounced search, replaces the static <Select> for templates
-interface TemplateSearchPickerProps {
-  value: string;               // selected template ID
-  initialName?: string;        // display name for the currently-selected template (pre-fill input)
-  onChange: (id: string) => void;
-}
-
-function TemplateSearchPicker({value, initialName, onChange}: TemplateSearchPickerProps) {
-  const [query, setQuery] = useState(initialName ?? '');
-  const [debouncedQuery, setDebouncedQuery] = useState('');
-  const [open, setOpen] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Sync display name when dialog re-opens with an existing selection
-  useEffect(() => {
-    setQuery(initialName ?? '');
-  }, [initialName]);
-
-  const handleInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target.value;
-    setQuery(val);
-    setOpen(true);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => setDebouncedQuery(val), 300);
-  }, []);
-
-  const {data, isLoading} = useSWR<PaginatedResponse<Template>>(
-    open || debouncedQuery
-      ? `/templates?pageSize=20${debouncedQuery ? `&search=${encodeURIComponent(debouncedQuery)}` : ''}`
-      : null,
-    {revalidateOnFocus: false},
-  );
-
-  const selectedName = value
-    ? (data?.data.find(t => t.id === value)?.name ?? initialName ?? value)
-    : '';
-
-  return (
-    <div className="relative">
-      <Input
-        type="text"
-        value={open ? query : selectedName}
-        onChange={handleInput}
-        onFocus={() => { setOpen(true); setDebouncedQuery(query); }}
-        onBlur={() => setTimeout(() => setOpen(false), 150)}
-        placeholder="Search templates…"
-        autoComplete="off"
-      />
-      {open && (
-        <div className="absolute z-50 w-full mt-1 rounded-md border border-neutral-200 bg-white shadow-md max-h-60 overflow-y-auto">
-          {isLoading ? (
-            <div className="px-3 py-2 text-sm text-neutral-500">Searching…</div>
-          ) : !data?.data.length ? (
-            <div className="px-3 py-2 text-sm text-neutral-500">No templates found</div>
-          ) : (
-            <Command>
-              <CommandList>
-                <CommandGroup>
-                  {data.data.map(t => (
-                    <CommandItem
-                      key={t.id}
-                      value={t.id}
-                      onSelect={() => {
-                        onChange(t.id);
-                        setQuery(t.name);
-                        setOpen(false);
-                      }}
-                    >
-                      <span className="flex-1 truncate">{t.name}</span>
-                      <span className="ml-2 text-xs text-neutral-400 shrink-0">{t.type}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          )}
-          {(data?.total ?? 0) > 20 && (
-            <div className="px-3 py-1.5 text-xs text-neutral-400 border-t border-neutral-100">
-              Showing 20 of {data!.total} — type to narrow results
-            </div>
-          )}
-        </div>
-      )}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Description

The workflow builder’s “Email Template” dropdown used to fetch only the first page of templates with `pageSize=100`, so instances with more than 100 templates could not see or select templates beyond that limit.

This PR replaces the capped dropdown with a debounced search against the full template dataset:

- In `apps/web/src/pages/workflows/[id].tsx`:
  - Remove the hard‑capped dropdown that fetched `/templates?pageSize=100`.
  - Add a debounced search input that queries templates on demand (20 results per request) from the entire template collection.
  - Wire the search results into both:
    - Add step dialog
    - Edit step dialog

This keeps the existing API contracts but removes the hard limit, making the selector responsive even for tenants with large template counts.

**Manual test steps**

1. Go to Workflows and open an existing workflow.
2. Add a `SEND_EMAIL` step and open the “Email Template” selector.
3. Type part of a template name that would previously be beyond the first 100; after a short debounce, verify it appears in the search results (up to 20 matching results returned per query).
4. Edit an existing `SEND_EMAIL` step and confirm you can search and select templates beyond the original 100‑item cap.

## Type of Change

- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat:` New feature (MINOR version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## PR Title Format

Suggested title (conventional commits):

`fix: improve workflow template selector with debounced search`

## Testing

Manually verified in a Plunk instance with >100 templates:

- Add step dialog: debounced search returns templates beyond index 100.
- Edit step dialog: debounced search also returns templates beyond index 100, and existing selections remain intact.

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)

## Related Issues

Closes #351