### PR TITLE
fix: emit List-Unsubscribe inside the MIME header section, not the body

### DIFF
--- a/apps/api/src/services/SESService.ts
+++ b/apps/api/src/services/SESService.ts
@@ -133,21 +133,23 @@ export async function sendRawEmail({
     rootContentType = `multipart/related; boundary="${relatedBoundary}"`;
   }
 
+  // Build the additional headers (custom headers + List-Unsubscribe), filtering
+  // out empties so we never emit a blank line inside the header section.
+  // Per RFC 5322 §2.1, a blank line terminates the header section, so any blank
+  // line here would push subsequent headers (notably List-Unsubscribe) into the body.
+  const extraHeaderLines = [
+    ...(headers ? Object.entries(headers).map(([key, value]) => `${key}: ${value}`) : []),
+    ...(unsubscribeHeader ? [unsubscribeHeader] : []),
+  ];
+  const extraHeaders = extraHeaderLines.length > 0 ? `\n${extraHeaderLines.join('\n')}` : '';
+
   // Build raw MIME message
   let rawMessage = `From: ${from.name} <${from.email}>
 To: ${toHeader}
 Reply-To: ${reply || from.email}
 Subject: ${content.subject}
 MIME-Version: 1.0
-Content-Type: ${rootContentType}
-${
-  headers
-    ? Object.entries(headers)
-        .map(([key, value]) => `${key}: ${value}`)
-        .join('\n')
-    : ''
-}
-${unsubscribeHeader}
+Content-Type: ${rootContentType}${extraHeaders}
 
 `;
 


### PR DESCRIPTION
## Description

When sending campaigns, the `List-Unsubscribe` header was being emitted in the message body instead of the header section. The raw MIME template in `sendRawEmail` (`apps/api/src/services/SESService.ts`) produced a blank line between `Content-Type` and `List-Unsubscribe` whenever no custom `headers` were passed (the common case for campaigns), because the ternary for custom headers expanded to an empty string surrounded by newlines.

Per RFC 5322 §2.1, a blank line terminates the header section, so `List-Unsubscribe` ended up as the first line of the body. Lenient clients (Gmail, Outlook) recover; strict clients (Thunderbird) do not, breaking one-click unsubscribe and degrading Gmail/Yahoo bulk-sender deliverability signals.

This PR collects the optional headers (custom + `List-Unsubscribe`) into an array, filters out empties, and appends them to the `Content-Type` line with a single newline separator. No codepath can now produce a blank line inside the header block. Existing custom-header behaviour is unchanged (same key-per-line format).

## Type of Change

- [ ] `feat:` New feature (MINOR version bump)
- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## PR Title Format

`fix: emit List-Unsubscribe inside the MIME header section, not the body`

## Testing

Bug originally observed in production by inspecting the raw source of a received campaign email: `List-Unsubscribe` appeared after a blank line, placing it in the message body rather than the header section. The fix was verified by reading the modified template literal — with no custom `headers`, the output now contains `Content-Type: ...\nList-Unsubscribe: ...\n\n` instead of `Content-Type: ...\n\nList-Unsubscribe: ...\n\n`. End-to-end send verification has not been performed.

## Checklist

- [x] PR title follows conventional commits format
- [ ] Code builds successfully
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)

## Related Issues

<!-- No existing issue tracks this bug. -->