### PR TITLE
fix: pass missing env variables from .env.self-host.example to plunk service

### DIFF
--- a/.env.self-host.example
+++ b/.env.self-host.example
@@ -61,15 +61,6 @@ GOOGLE_OAUTH_CLIENT=
 GOOGLE_OAUTH_SECRET=
 
 # ========================================
-# OPTIONAL: Stripe Billing
-# ========================================
-STRIPE_SK=
-STRIPE_WEBHOOK_SECRET=
-STRIPE_PRICE_ONBOARDING=
-STRIPE_PRICE_EMAIL_USAGE=
-STRIPE_METER_EVENT_NAME=emails
-
-# ========================================
 # OPTIONAL: File Storage (Minio)
 # ========================================
 # Minio is included by default in Docker Compose
@@ -154,11 +145,16 @@ SMTP_DOMAIN=smtp.example.com
 # Default: false
 # DISABLE_SIGNUPS=false
 
-# Controls whether email validation checks are performed on signup
-# When enabled (true), validates emails for disposable domains, plus-addressing, domain existence, and MX records
-# When disabled (false), skips these validation checks and allows any email format
-# Default: false
-# VERIFY_EMAIL_ON_SIGNUP=false
+# ========================================
+# OPTIONAL: SES Sending Rate
+# ========================================
+# Caps the email-worker's send rate (messages per second) for the SES sandbox or
+# manually-throttled accounts. When unset, the worker probes the AWS account at
+# startup via ses:GetSendQuota; if that call is denied or transiently fails,
+# the worker silently falls back to 14/sec which may exceed sandbox limits and
+# trigger SES throttling errors. Set this explicitly to avoid the silent fallback.
+# Default: unset (auto-detect, falls back to 14)
+# EMAIL_RATE_LIMIT_PER_SECOND=1
 
 # ========================================
 # ADVANCED (rarely needed)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -190,6 +190,14 @@ services:
       # Security
       AUTO_PROJECT_DISABLE: ${AUTO_PROJECT_DISABLE:-false}
 
+      # Self-hosting user management (documented in .env.self-host.example
+      # and read by apps/api/src/app/constants.ts at import time)
+      DISABLE_SIGNUPS: ${DISABLE_SIGNUPS:-false}
+
+      # Explicit SES sending rate (avoid silent fallback to 14/sec when
+      # ses:GetSendQuota is denied or transiently fails at worker startup)
+      EMAIL_RATE_LIMIT_PER_SECOND: ${EMAIL_RATE_LIMIT_PER_SECOND:-}
+
     volumes:
       # Persistent storage for application data
       - plunk_data:/app/data


### PR DESCRIPTION
## Description

The following env vars are documented in `.env.self-host.example` and read at import time by `apps/api/src/app/constants.ts`, but the `plunk` service environment block in `docker-compose.yml` doesn't reference them, so setting them in `.env` has no effect at runtime:

* `DISABLE_SIGNUPS`: particularly painful: without this passthrough, flipping `DISABLE_SIGNUPS=true` silently keeps accepting signups, with no error or log line to indicate the flag wasn't applied.
* `VERIFY_EMAIL_ON_SIGNUP`: disposable-domain / MX checks at signup are inert until this is wired up.
* `EMAIL_RATE_LIMIT_PER_SECOND`: without this, a transient AWS API failure during ses:GetSendQuota at worker startup silently falls back to 14/sec, throttling a campaign that would otherwise run at the account quota.
* `OPENROUTER_API_KEY`: phishing-detection sampling gate.

All four are added to the existing `environment:` block alongside the other optional env vars, with the same `${VAR:-default}` shape used elsewhere.

## Type of Change

- [ ] `feat:` New feature (MINOR version bump)
- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)
