### PR TITLE
feat: make MAIL FROM subdomain configurable via MAIL_FROM_SUBDOMAIN env

### DIFF
--- a/.env.self-host.example
+++ b/.env.self-host.example
@@ -52,6 +52,13 @@ SES_CONFIGURATION_SET=plunk-configuration-set
 # When set, projects can choose to disable email tracking
 SES_CONFIGURATION_SET_NO_TRACKING=plunk-no-tracking-configuration-set
 
+# Custom MAIL FROM subdomain — used to construct `<subdomain>.<your-domain>`
+# when a domain is added. Defaults to `plunk`. Override when `plunk.<your-domain>`
+# is already used for something else (e.g. an R2/CDN custom domain), since the
+# MAIL FROM hostname needs MX + TXT records that can't coexist with a CNAME.
+# Example: MAIL_FROM_SUBDOMAIN=emails  →  emails.<your-domain>
+# MAIL_FROM_SUBDOMAIN=
+
 # ========================================
 # OPTIONAL: OAuth Login
 # ========================================

--- a/apps/api/src/app/constants.ts
+++ b/apps/api/src/app/constants.ts
@@ -45,6 +45,12 @@ export const AWS_SES_REGION = validateEnv('AWS_SES_REGION');
 export const AWS_SES_ACCESS_KEY_ID = validateEnv('AWS_SES_ACCESS_KEY_ID');
 export const AWS_SES_SECRET_ACCESS_KEY = validateEnv('AWS_SES_SECRET_ACCESS_KEY');
 
+// Custom MAIL FROM subdomain used to construct `<subdomain>.<your-domain>`
+// when a domain is added. Defaults to `plunk`. Override when `plunk.<your-domain>`
+// is already used for something else (e.g. a CDN), since the MAIL FROM hostname
+// needs MX + TXT records that can't coexist with a CNAME.
+export const MAIL_FROM_SUBDOMAIN = validateEnv('MAIL_FROM_SUBDOMAIN', '').trim() || 'plunk';
+
 // Email Processing Rate Limit (optional override)
 // If not set, will automatically fetch from AWS SES account quota
 // Set this to override AWS quota (useful for setting lower limits or testing)

--- a/apps/api/src/controllers/Config.ts
+++ b/apps/api/src/controllers/Config.ts
@@ -8,6 +8,7 @@ import {
   GITHUB_OAUTH_ENABLED,
   GOOGLE_OAUTH_ENABLED,
   LANDING_URI,
+  MAIL_FROM_SUBDOMAIN,
   NODE_ENV,
   S3_ENABLED,
   SMTP_DOMAIN,
@@ -62,6 +63,7 @@ export class Config {
       },
       aws: {
         sesRegion: AWS_SES_REGION,
+        mailFromSubdomain: MAIL_FROM_SUBDOMAIN,
       },
     });
   }

--- a/apps/api/src/services/SESService.ts
+++ b/apps/api/src/services/SESService.ts
@@ -6,6 +6,7 @@ import {
   AWS_SES_REGION,
   AWS_SES_SECRET_ACCESS_KEY,
   DASHBOARD_URI,
+  MAIL_FROM_SUBDOMAIN,
   SES_CONFIGURATION_SET,
   SES_CONFIGURATION_SET_NO_TRACKING,
   TRACKING_TOGGLE_ENABLED,
@@ -250,10 +251,13 @@ export const verifyDomain = async (domain: string): Promise<string[]> => {
   // Verify DKIM for the domain
   const DKIM = await ses.verifyDomainDkim({Domain: domain});
 
-  // Set custom MAIL FROM domain (plunk.yourdomain.com)
+  // Set custom MAIL FROM domain. The subdomain defaults to `plunk` and can be
+  // overridden via the MAIL_FROM_SUBDOMAIN env var — useful when `plunk.<domain>`
+  // is already in use for something else (e.g., a CNAME to a CDN), since the
+  // MAIL FROM subdomain needs MX + TXT records that conflict with a CNAME.
   await ses.setIdentityMailFromDomain({
     Identity: domain,
-    MailFromDomain: `plunk.${domain}`,
+    MailFromDomain: `${MAIL_FROM_SUBDOMAIN}.${domain}`,
   });
 
   return DKIM.DkimTokens ?? [];

--- a/apps/web/src/components/DomainsSettings.tsx
+++ b/apps/web/src/components/DomainsSettings.tsx
@@ -335,6 +335,8 @@ export function DomainsSettings({projectId}: DomainsSettingsProps) {
             <div className="space-y-4">
               {domains.map(domain => {
                 const status = getDomainStatus(domain);
+                const mailFromSubdomain = config?.aws?.mailFromSubdomain ?? 'plunk';
+                const mailFromHost = `${mailFromSubdomain}.${domain.domain}`;
                 return (
                   <div key={domain.id} className="border border-neutral-200 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-3">
@@ -494,8 +496,8 @@ export function DomainsSettings({projectId}: DomainsSettingsProps) {
                                   </Badge>
                                 </div>
                                 <p className="text-xs text-neutral-600 mb-2">
-                                  Set up a custom MAIL FROM domain (plunk.{domain.domain}) to improve deliverability and
-                                  handle bounces/complaints.
+                                  Set up a custom MAIL FROM domain ({mailFromHost}) to improve deliverability and handle
+                                  bounces/complaints.
                                 </p>
 
                                 <div className="overflow-x-auto">
@@ -522,16 +524,16 @@ export function DomainsSettings({projectId}: DomainsSettingsProps) {
                                         <td className="py-3 px-3">
                                           <div className="flex items-center gap-2">
                                             <code className="text-xs font-mono text-neutral-700 break-all flex-1">
-                                              plunk.{domain.domain}
+                                              {mailFromHost}
                                             </code>
                                             <Button
                                               variant="ghost"
                                               size="sm"
-                                              onClick={() => handleCopyToken(`plunk.${domain.domain}`, 3000)}
+                                              onClick={() => handleCopyToken(mailFromHost, 3000)}
                                               className="shrink-0 h-6 w-6 p-0 overflow-hidden"
                                             >
                                               <AnimatedCopyIcon
-                                                isCopied={copiedToken === `plunk.${domain.domain}-3000`}
+                                                isCopied={copiedToken === `${mailFromHost}-3000`}
                                               />
                                             </Button>
                                           </div>
@@ -571,16 +573,16 @@ export function DomainsSettings({projectId}: DomainsSettingsProps) {
                                         <td className="py-3 px-3">
                                           <div className="flex items-center gap-2">
                                             <code className="text-xs font-mono text-neutral-700 break-all flex-1">
-                                              plunk.{domain.domain}
+                                              {mailFromHost}
                                             </code>
                                             <Button
                                               variant="ghost"
                                               size="sm"
-                                              onClick={() => handleCopyToken(`plunk.${domain.domain}`, 3001)}
+                                              onClick={() => handleCopyToken(mailFromHost, 3001)}
                                               className="shrink-0 h-6 w-6 p-0 overflow-hidden"
                                             >
                                               <AnimatedCopyIcon
-                                                isCopied={copiedToken === `plunk.${domain.domain}-3001`}
+                                                isCopied={copiedToken === `${mailFromHost}-3001`}
                                               />
                                             </Button>
                                           </div>

--- a/apps/web/src/lib/hooks/useConfig.ts
+++ b/apps/web/src/lib/hooks/useConfig.ts
@@ -21,6 +21,7 @@ export interface ConfigResponse {
   };
   aws: {
     sesRegion: string;
+    mailFromSubdomain: string;
   };
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,10 @@ services:
       SES_CONFIGURATION_SET: ${SES_CONFIGURATION_SET}
       SES_CONFIGURATION_SET_NO_TRACKING: ${SES_CONFIGURATION_SET_NO_TRACKING:-}
 
+      # Custom MAIL FROM subdomain (defaults to 'plunk'; override when
+      # plunk.<your-domain> is already used for something else, e.g. a CDN)
+      MAIL_FROM_SUBDOMAIN: ${MAIL_FROM_SUBDOMAIN:-}
+
       # Optional: OAuth
       GITHUB_OAUTH_CLIENT: ${GITHUB_OAUTH_CLIENT:-}
       GITHUB_OAUTH_SECRET: ${GITHUB_OAUTH_SECRET:-}


### PR DESCRIPTION
## Description

`SESService.verifyDomain` uses a hardcoded `MailFromDomain: plunk.${domain}` when adding a new sending domain.

For most self-hosters that's fine, but on deployments where `plunk.<their-domain>` is already in use for something else (typically a `CNAME` to a CDN, e.g. an R2/S3 bucket's custom public domain), the hardcoded choice silently fails: the `MAIL FROM` subdomain needs `MX` + `TXT` records that DNS won't let coexist with a `CNAME` on the same host.

This change makes the subdomain configurable via a new optional `MAIL_FROM_SUBDOMAIN` env var, defaulting to plunk for full backward compatibility. Trimmed empty string falls back to the default.

Wiring:

* Add `MAIL_FROM_SUBDOMAIN` to `apps/api/src/app/constants.ts` using the existing `validateEnv('VAR', default)` pattern, alongside the other AWS-related env reads.
* Use the constant in `SESService.verifyDomain` when calling `setIdentityMailFromDomain`.
* Pass through in `docker-compose.yml` so the value reaches the plunk container.
* Document in `.env.self-host.example` with a usage example.

Dashboard:

The DNS-records UI on the Settings → Domains tab also hardcoded `plunk.${domain.domain}` in four places (the `MX`, `TXT`, and copy-button strings), which would tell a self-hoster with `MAIL_FROM_SUBDOMAIN=emails` to create records on the wrong hostname. Fixed by exposing `mailFromSubdomain` on the existing public `/config` endpoint (`aws.mailFromSubdomain`) and reading it in `DomainsSettings.tsx` via the existing `useConfig` hook. Falls back to `plunk` if config hasn't loaded yet.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [x] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Testing

Verified locally: `yarn build --filter=api --filter=web --force` passes; manually set `MAIL_FROM_SUBDOMAIN=emails` and confirmed Plunk's `setIdentityMailFromDomain` call uses `emails.<domain>` and the dashboard DNS records render `emails.<domain>` for both `MX` and `TXT` rows.

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)