### PR TITLE
fix: .dockerignore excludes nested build outputs (apps/*/dist, .next, .turbo, etc.)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,22 @@
 # Dependencies
 node_modules
+**/node_modules
 .pnp
 .pnp.js
 
 # Build outputs
-dist
-.next
-.turbo
-out
+# Patterns without a leading `**/` only match the build-context root, NOT
+# nested directories. In this monorepo the actual outputs live under
+# apps/*/{dist,.next,.turbo} and packages/*/{dist,.turbo}; without `**/`
+# any stale local builds (from running `yarn dev` or `yarn build` on the
+# host) get copied into the image and override the freshly-built outputs,
+# producing silently broken builds (MODULE_NOT_FOUND for whatever the stale
+# bundle still references).
+**/dist
+**/.next
+**/.turbo
+**/build
+**/out
 
 # Development
 .env


### PR DESCRIPTION
## Description

This was a bit painful to troubleshoot and I would expect anybody that is selfhosting and doing local patches run into a similar issue.

The problem: `.dockerignore` patterns like `dist`, `.next`, `.turbo`, `build`, `out`, and `node_modules` without a leading `**/` only match the build-context root, not nested directories.

But in this monorepo the real build outputs live under `apps/*/{dist,.next,.turbo}` and `packages/*/{dist,.turbo}`, so any stale local builds on the host (from a prior `yarn dev` / `yarn build`) get included in the Docker build context and `COPY`'d over the freshly-built artifacts.

Meaning that the resulting image silently runs old code and throws `MODULE_NOT_FOUND` at request time for whatever the stale bundle still references but the current `node_modules` tree doesn't include anymore, with no log line pointing back at the actual cause.

I found out after resetting back to origin/next and still getting errors without any commits on top (but the stale dist still lingering around)

This patch adds `**/` to each build-output and `node_modules` pattern so they match at any depth. The testing patterns further down below in the `.dockerignore` (`**/__tests__`, `**/*.test.ts`, etc.) already use this form, so this just brings the build-output rules in line with the existing convention.

## Type of Change

  - [ ] `feat:` New feature (MINOR version bump)
  - [x] `fix:` Bug fix (PATCH version bump)
  - [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
  - [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
  - [ ] `docs:` Documentation update (no version bump)
  - [ ] `chore:` Maintenance/dependencies (no version bump)
  - [ ] `refactor:` Code refactoring (no version bump)
  - [ ] `test:` Adding tests (no version bump)
  - [ ] `perf:` Performance improvement (PATCH version bump)


## Testing

* Reproduced the bug: ran `yarn build` on the host to populate `apps/*/dist` and `apps/web/.next`, then `docker compose build`. Resulting image threw `MODULE_NOT_FOUND` on container start (the package this surfaces on depends on which stale `dist/` happens to be lying around. In my case it was redux-toolkit; I've also seen redux and sanitize-html depending on prior local state).
* Re-built with the patched `.dockerignore`: image starts cleanly and serves traffic; standalone Next output uses the fresh in-image bundles.
* Verified via `docker build --progress=plain` that the nested `apps/*/{dist,.next,.turbo}` and `packages/*/dist` directories are no longer enumerated in the build context.

## Checklist

  - [x] PR title follows conventional commits format
  - [x] Code builds successfully
  - [x] Tests pass locally
  - [x] Documentation updated (if needed)