### PR TITLE
fix: clarify SES no-tracking config set failures

### DIFF
--- a/apps/api/src/services/SESService.ts
+++ b/apps/api/src/services/SESService.ts
@@ -213,21 +213,34 @@ ${breakLongLines(attachment.content, 76, true)}`;
   const configurationSetName =
     TRACKING_TOGGLE_ENABLED && !tracking ? SES_CONFIGURATION_SET_NO_TRACKING : SES_CONFIGURATION_SET;
 
-  // Send via SES
-  const response = await ses.sendRawEmail({
-    Destinations: destinations,
-    ConfigurationSetName: configurationSetName,
-    RawMessage: {
-      Data: new TextEncoder().encode(rawMessage),
-    },
-    Source: `${from.name} <${from.email}>`,
-  });
+  try {
+    // Send via SES
+    const response = await ses.sendRawEmail({
+      Destinations: destinations,
+      ConfigurationSetName: configurationSetName,
+      RawMessage: {
+        Data: new TextEncoder().encode(rawMessage),
+      },
+      Source: `${from.name} <${from.email}>`,
+    });
 
-  if (!response.MessageId) {
-    throw new Error('Could not send email');
+    if (!response.MessageId) {
+      throw new Error('Could not send email');
+    }
+
+    return {messageId: response.MessageId};
+  } catch (error) {
+    const originalMessage = error instanceof Error ? error.message : String(error);
+    const noTrackingMessage =
+      TRACKING_TOGGLE_ENABLED && !tracking
+        ? ' If this was a preview/test email, verify SES_CONFIGURATION_SET_NO_TRACKING exists in AWS SES.'
+        : '';
+
+    throw new Error(
+      `Failed to send email via SES using configuration set "${configurationSetName}".${noTrackingMessage} Original error: ${originalMessage}`,
+      {cause: error},
+    );
   }
-
-  return {messageId: response.MessageId};
 }
 
 /**


### PR DESCRIPTION
## Description

This PR improves server-side error reporting when AWS SES rejects an email because the selected "no-tracking" configuration set does not exist. I ran into this while trying to send a preview email for a campaign, which didn't work and only returned a minimal error message.

Preview/test campaign emails disable tracking, which causes the API to use `SES_CONFIGURATION_SET_NO_TRACKING` when the tracking toggle is enabled. If that no-tracking configuration set is missing or misconfigured in AWS SES, the previous error was insufficient from the server logs.

This change wraps the SES `sendRawEmail` call with contextual error handling and includes:
- the SES configuration set name used for the send
- a specific hint for preview/test emails using `SES_CONFIGURATION_SET_NO_TRACKING`
- the original SES error message
- the original error as the `cause`

## Type of Change

- [ ] `feat:` New feature (MINOR version bump)
- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Testing

Tested manually in a local Docker setup by invoking `sendRawEmail` inside the API container with:

- `tracking: false`
- `SES_CONFIGURATION_SET_NO_TRACKING=plunk-no-tracking-configuration-set`
- valid AWS SES credentials

Confirmed the server-side error now includes:

```txt
Failed to send email via SES using configuration set "plunk-no-tracking-configuration-set". If this was a preview/test email, verify SES_CONFIGURATION_SET_NO_TRACKING exists in AWS SES. Original error: Configuration set <plunk-no-tracking-configuration-set> does not exist.
```