### PR TITLE
feat: add copy-to-clipboard button for template IDs on templates list…

### DIFF
--- a/apps/web/src/pages/templates/index.tsx
+++ b/apps/web/src/pages/templates/index.tsx
@@ -13,7 +13,7 @@ import {EmptyState} from '@plunk/ui';
 import {DashboardLayout} from '../../components/DashboardLayout';
 import {network} from '../../lib/network';
 import {formatRelativeTime} from '../../lib/dateUtils';
-import {Calendar, Copy, Edit, FileText, Plus, Search, Trash2, X} from 'lucide-react';
+import {Calendar, Files, Copy, Edit, FileText, Plus, Search, Trash2, X} from 'lucide-react';
 import {NextSeo} from 'next-seo';
 import Link from 'next/link';
 import {useEffect, useState} from 'react';
@@ -63,6 +63,15 @@ export default function TemplatesPage() {
       void mutate();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to duplicate template');
+    }
+  };
+
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label} copied to clipboard`);
+    } catch {
+      toast.error('Failed to copy');
     }
   };
 
@@ -193,6 +202,14 @@ export default function TemplatesPage() {
                           </div>
                         </div>
                         <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            title="Copy template ID"
+                            onClick={() => copyToClipboard(template.id, 'Template ID')}
+                          >
+                            <Files className="h-4 w-4" />
+                          </Button>
                           <Button asChild variant="ghost" size="sm" title="Edit template">
                             <Link href={`/templates/${template.id}`} aria-label="Edit template"><Edit className="h-4 w-4" /></Link>
                           </Button>


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Adds a "Copy template ID" button to each template card on the templates list page. This makes it easy to quickly copy a template's id for use in API calls without having to navigate into the template detail view.

- Added ClipboardCopy icon button alongside existing Edit, Duplicate, and Delete actions
- Uses navigator.clipboard.writeText() with toast feedback via sonner
- Follows the same handler pattern (async/try/catch/toast) used by the existing handleDelete and handleDuplicate functions
<img width="1236" height="370" alt="image" src="https://github.com/user-attachments/assets/edcf87ae-3c81-4bd0-8c67-b562681cf457" />



<!-- Mark the appropriate option with an 'x' -->

- [x] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)


## Testing

- Verified the button renders on each template card in the list view
- Confirmed clicking the button copies  the template UUID to clipboard and shows a success toast
- The project builds without any errors

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)
