### PR TITLE
feat(contacts): make email cell a link to the contact detail page

### DIFF
--- a/apps/web/src/pages/contacts/index.tsx
+++ b/apps/web/src/pages/contacts/index.tsx
@@ -405,7 +405,12 @@ export default function ContactsPage() {
                                 ) : (
                                   <MailX className="h-4 w-4 text-red-600" />
                                 )}
-                                <span className="text-sm font-medium text-neutral-900">{contact.email}</span>
+                                <Link
+                                  href={`/contacts/${contact.id}`}
+                                  className="text-sm font-medium text-neutral-900 hover:text-neutral-700 focus-visible:outline-none focus-visible:underline"
+                                >
+                                  {contact.email}
+                                </Link>
                               </div>
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap">
@@ -455,7 +460,12 @@ export default function ContactsPage() {
                             ) : (
                               <MailX className="h-4 w-4 text-red-600 flex-shrink-0" />
                             )}
-                            <span className="text-sm font-medium text-neutral-900 truncate">{contact.email}</span>
+                            <Link
+                              href={`/contacts/${contact.id}`}
+                              className="text-sm font-medium text-neutral-900 truncate hover:text-neutral-700 focus-visible:outline-none focus-visible:underline"
+                            >
+                              {contact.email}
+                            </Link>
                           </div>
                           <span
                             className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${


### PR DESCRIPTION
## Description

[Currently the only entry point from the /contacts list to a contact's detail page is the small Edit icon-button in the actions column](https://discord.com/channels/990573272561242162/990573273144229900/1504068724775456788). This is somewhat counterintuitive:

<img width="646" height="233" alt="image" src="https://github.com/user-attachments/assets/2e42b3e0-d01e-4408-ad94-5f37e8744eb3" />

This PR makes the email itself a Link to /contacts/:id so the obvious affordance ("click the thing that identifies the row") works too. Applied to both the desktop table cell and the mobile card variant.

## Type of Change

<!-- Mark the appropriate option with an 'x' -->

- [x] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Testing

Tested locally

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)