### PR TITLE
fix: make email templates, campaigns and workflow search inputs same height as the rest of the app

### DIFF
--- a/apps/web/src/pages/campaigns/index.tsx
+++ b/apps/web/src/pages/campaigns/index.tsx
@@ -252,7 +252,7 @@ export default function CampaignsPage() {
           </div>
 
           {/* Search & Filters */}
-          <div className="flex flex-col sm:flex-row gap-3">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
               <Input
@@ -260,7 +260,7 @@ export default function CampaignsPage() {
                 placeholder="Search campaigns..."
                 value={searchInput}
                 onChange={e => setSearchInput(e.target.value)}
-                className="pl-10 pr-10"
+                className="pl-10 pr-10 h-8 text-xs"
               />
               {searchInput && (
                 <button

--- a/apps/web/src/pages/templates/index.tsx
+++ b/apps/web/src/pages/templates/index.tsx
@@ -90,7 +90,7 @@ export default function TemplatesPage() {
           </div>
 
           {/* Search & Filters */}
-          <div className="flex flex-col sm:flex-row gap-3">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400" />
               <Input
@@ -98,7 +98,7 @@ export default function TemplatesPage() {
                 placeholder="Search templates..."
                 value={searchInput}
                 onChange={e => setSearchInput(e.target.value)}
-                className="pl-10 pr-10"
+                className="pl-10 pr-10 h-8 text-xs"
               />
               {searchInput && (
                 <button

--- a/apps/web/src/pages/workflows/index.tsx
+++ b/apps/web/src/pages/workflows/index.tsx
@@ -117,7 +117,7 @@ export default function WorkflowsPage() {
               placeholder="Search workflows..."
               value={searchInput}
               onChange={e => setSearchInput(e.target.value)}
-              className="pl-10 pr-10"
+              className="pl-10 pr-10 h-8 text-xs"
             />
             {searchInput && (
               <button


### PR DESCRIPTION
## Description

Tiny UI fix:

<img width="1512" height="828" alt="image" src="https://github.com/user-attachments/assets/0feb9499-8b75-4e77-a5ee-bec3c83f01ca" />

On /templates the Input defaults to h-9 (36px) while the size="sm" filter Buttons in the same row are h-8 (32px) which creates a visual gap on desktop. On /workflows the search bar is alone in the row so the mismatch isn't visible, but it would if that page would ever get some filters as well. On /campaigns the status-filter buttons sit next to the search bar and the stretch is obvious. Shrink the search Input to h-8 text-xs on both pages and add sm:items-center to the campaigns filter row so the controls vertically center.

## Type of Change

- [ ] `feat:` New feature (MINOR version bump)
- [x] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [ ] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Testing

Checked locally (see screenshots)

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [x] Documentation updated (if needed)