### PR TITLE
fix: support prefixed SNS webhook routes

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -25,6 +25,7 @@ import {
 import {Actions} from './controllers/Actions.js';
 import {Activity} from './controllers/Activity.js';
 import {Analytics} from './controllers/Analytics.js';
+import {ApiPrefixedWebhooks} from './controllers/ApiPrefixedWebhooks.js';
 import {Auth} from './controllers/Auth.js';
 import {Campaigns} from './controllers/Campaigns.js';
 import {Contacts} from './controllers/Contacts.js';
@@ -161,6 +162,7 @@ const server = new (class extends Server {
       new Templates(),
       new Uploads(),
       new Webhooks(),
+      new ApiPrefixedWebhooks(),
       new Workflows(),
       new Events(),
       new Config(),

--- a/apps/api/src/controllers/ApiPrefixedWebhooks.ts
+++ b/apps/api/src/controllers/ApiPrefixedWebhooks.ts
@@ -1,0 +1,23 @@
+import {Controller, Post} from '@overnightjs/core';
+import type {Request, Response} from 'express';
+
+import {CatchAsync} from '../utils/asyncHandler.js';
+import {Webhooks} from './Webhooks.js';
+
+/**
+ * Compatibility aliases for deployments that expose the API under /api.
+ */
+@Controller('api/webhooks')
+export class ApiPrefixedWebhooks extends Webhooks {
+  @Post('sns')
+  @CatchAsync
+  public async receiveSNSWebhook(req: Request, res: Response) {
+    return this.handleSNSWebhook(req, res);
+  }
+
+  @Post('incoming/sns')
+  @CatchAsync
+  public async receiveIncomingSNSWebhook(req: Request, res: Response) {
+    return this.handleSNSWebhook(req, res);
+  }
+}

--- a/apps/api/src/controllers/Webhooks.ts
+++ b/apps/api/src/controllers/Webhooks.ts
@@ -36,6 +36,16 @@ export class Webhooks {
   @Post('sns')
   @CatchAsync
   public async receiveSNSWebhook(req: Request, res: Response) {
+    return this.handleSNSWebhook(req, res);
+  }
+
+  @Post('incoming/sns')
+  @CatchAsync
+  public async receiveIncomingSNSWebhook(req: Request, res: Response) {
+    return this.handleSNSWebhook(req, res);
+  }
+
+  protected async handleSNSWebhook(req: Request, res: Response) {
     try {
       // Verify SNS message signature before processing anything
       const signatureValid = await SecurityService.verifySnsSignature(req.body as Record<string, string>);

--- a/apps/wiki/content/docs/api-reference/overview.mdx
+++ b/apps/wiki/content/docs/api-reference/overview.mdx
@@ -389,6 +389,9 @@ These endpoints receive events from the underlying email and billing infrastruct
 | Method | Path                          |
 | ------ | ----------------------------- |
 | POST   | `/webhooks/sns`               |
+| POST   | `/api/webhooks/sns`           |
+| POST   | `/webhooks/incoming/sns`      |
+| POST   | `/api/webhooks/incoming/sns`  |
 | POST   | `/webhooks/incoming/stripe`   |
 
 ## Client libraries

--- a/apps/wiki/content/docs/self-hosting/email-setup.mdx
+++ b/apps/wiki/content/docs/self-hosting/email-setup.mdx
@@ -42,6 +42,7 @@ description: Configure email delivery
 5. Create subscription:
    - Protocol: HTTPS
    - Endpoint: `https://api.yourdomain.com/webhooks/sns`
+   - If your reverse proxy serves Plunk at a path prefix such as `https://yourdomain.com/api`, use `https://yourdomain.com/api/webhooks/sns` instead.
 6. Plunk automatically confirms the subscription. If it fails, check your logs for the confirmation URL.
 
 ## 3. Create Configuration Sets
@@ -85,7 +86,7 @@ Not all AWS regions support SES inbound — confirm `inbound-smtp.<your-region>.
 1. SES Console → **Email receiving** → **Rule sets** → Create rule set (or use an existing one)
 2. Add a rule:
    - **Recipient conditions**: `*@yourdomain.com` (or specific addresses you want to receive)
-   - **Actions**: Publish to Amazon SNS topic → select your `plunk-ses-events` topic (or create a separate topic that's also subscribed to `https://api.yourdomain.com/webhooks/sns`)
+   - **Actions**: Publish to Amazon SNS topic → select your `plunk-ses-events` topic (or create a separate topic that's also subscribed to `https://api.yourdomain.com/webhooks/sns`; use `/api/webhooks/sns` if your deployment exposes the API under `/api`)
 3. Set the rule set as **active**
 
 ### Inbound IAM permissions
@@ -119,4 +120,3 @@ After approval, your sending quota will reflect a much higher daily and per-seco
 ## 8. (Optional) Configure a MAIL FROM Domain
 
 For better DMARC alignment, you can configure a custom MAIL FROM subdomain (e.g. `mail.yourdomain.com`). In the SES console under **Verified identities** → your domain → **MAIL FROM domain**, set a subdomain and add the additional MX and TXT records SES displays. Plunk's IAM policy already includes `ses:SetIdentityMailFromDomain` to support this.
-


### PR DESCRIPTION
Fixes #385.

## What changed
- Keeps the existing `POST /webhooks/sns` handler as the canonical SNS endpoint.
- Adds `POST /webhooks/incoming/sns` for consistency with the existing incoming webhook shape.
- Adds `/api/webhooks/sns` and `/api/webhooks/incoming/sns` compatibility routes for deployments that expose the API behind an `/api` path prefix.
- Documents the `/api` endpoint variant for self-hosted reverse-proxy setups.

## Checks
- `yarn install --immutable`
- `yarn workspace @plunk/db build`
- `yarn workspace @plunk/types build`
- `yarn workspace @plunk/shared build`
- `yarn workspace @plunk/email build`
- `yarn exec tsc -p apps/api/tsconfig.json --noEmit`
- `git diff --check`

I also tried the repo lint path. ESLint is blocked before file linting by the current ESLint 9 / `.eslintrc.js` config mismatch (`eslint.config.*` not found, then legacy config circular-structure error with `ESLINT_USE_FLAT_CONFIG=false`).

Update: maintainer feedback clarified that this is not the intended fix for #385; the correct setup is to use the API domain's `/webhooks/sns` endpoint directly. I closed this PR rather than pushing the wrong direction.
