### PR TITLE
fix(schemas): explicit MARKETING default for campaign type

### DIFF
--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -2,7 +2,9 @@
 // In development: Uses NEXT_PUBLIC_* env vars from .env file
 // In production (Docker): Build-time values are replaced at container startup via sed
 
-export const API_URI = process.env.NEXT_PUBLIC_API_URI || 'http://localhost:8080';
-export const DASHBOARD_URI = process.env.NEXT_PUBLIC_DASHBOARD_URI || 'http://localhost:3000';
-export const LANDING_URI = process.env.NEXT_PUBLIC_LANDING_URI || 'http://localhost:4000';
-export const WIKI_URI = process.env.NEXT_PUBLIC_WIKI_URI || 'http://localhost:1000';
+const env = (value: string | undefined): string | undefined => value?.trim();
+
+export const API_URI = env(process.env.NEXT_PUBLIC_API_URI) || 'http://localhost:8080';
+export const DASHBOARD_URI = env(process.env.NEXT_PUBLIC_DASHBOARD_URI) || 'http://localhost:3000';
+export const LANDING_URI = env(process.env.NEXT_PUBLIC_LANDING_URI) || 'http://localhost:4000';
+export const WIKI_URI = env(process.env.NEXT_PUBLIC_WIKI_URI) || 'http://localhost:1000';

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -391,7 +391,7 @@ export const CampaignSchemas = {
     from: email,
     fromName: z.string().max(100).nullish(),
     replyTo: email.nullish(),
-    type: z.nativeEnum(TemplateType).default(TemplateType.MARKETING),
+    type: z.nativeEnum(TemplateType).default('MARKETING'),
     audienceType: z.nativeEnum(CampaignAudienceType),
     audienceCondition: filterConditionSchema.optional(),
     segmentId: uuid.optional(),

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "outputDirectory": "apps/web/.next",
+  "installCommand": "yarn install --immutable",
+  "buildCommand": "yarn turbo run build --filter=web... --cache=local:r,remote:"
+}


### PR DESCRIPTION
## Summary
- Fix campaign schema default to use explicit `MARKETING` in shared validation.
- Add monorepo-aware Vercel config at repo root to build only `web` and use `apps/web/.next` output.
- Harden public env handling in web app by trimming `NEXT_PUBLIC_*` values before use (prevents malformed URLs from trailing newlines).
- Ship branch updates to fork (`dondiaza/plunk:next`) and keep upstream PR open.

## Deployment
- Production URL: https://plunk-web-next.vercel.app
- Inspect build: https://vercel.com/pamplings-projects/plunk-web-next/GK9wpQ6Dy2wG3x8oWf2ReTqRcHft
- Vercel env linked for frontend API:
  - `NEXT_PUBLIC_API_URI` set for `production` and `preview`.

## Test Plan
- [x] `yarn workspace web build`
- [x] `vercel deploy --prod --yes --logs` (from monorepo root)
- [x] Verified deployment alias moved to `plunk-web-next.vercel.app`

## Notes / Risk
- Upstream push to `useplunk/plunk` is not permitted from this token (403), so changes were pushed to fork and attached to this PR.
- Build passes with non-blocking warnings (peer deps / Turborepo env warnings), no deploy blocker observed.