### PR TITLE
fix: coerce boolean and numeric values in custom CSV columns

### DIFF
--- a/apps/api/src/jobs/__tests__/import-processor.test.ts
+++ b/apps/api/src/jobs/__tests__/import-processor.test.ts
@@ -292,8 +292,40 @@ describe('coerceCustomValue', () => {
     });
   });
 
+  describe('number coercion', () => {
+    it.each([
+      ['42', 42],
+      ['-7', -7],
+      ['3.14', 3.14],
+      [' 42 ', 42],
+      ['0.5', 0.5],
+      ['-0.25', -0.25],
+    ])('coerces %j to %j', (value, expected) => {
+      expect(coerceCustomValue(value)).toBe(expected);
+    });
+
+    it.each(['01234', '+42', '.5', '42.', '1e10', 'NaN', 'Infinity', '1.2.3', '4-2'])(
+      'leaves %j as a string (preserves IDs / rejects loose formats)',
+      value => {
+        expect(coerceCustomValue(value)).toBe(value);
+      },
+    );
+
+    it('keeps boolean precedence: "1" stays boolean true, not number 1', () => {
+      expect(coerceCustomValue('1')).toBe(true);
+    });
+
+    it('keeps boolean precedence: "0" stays boolean false, not number 0', () => {
+      expect(coerceCustomValue('0')).toBe(false);
+    });
+
+    it('"1.0" is a number (does not match the boolean truthy set)', () => {
+      expect(coerceCustomValue('1.0')).toBe(1);
+    });
+  });
+
   describe('passthrough', () => {
-    it.each(['Alice', 'true!', 'yesno', 'maybe', '42', '3.14', '01234'])('leaves %j as a string', value => {
+    it.each(['Alice', 'true!', 'yesno', 'maybe'])('leaves %j as a string', value => {
       expect(coerceCustomValue(value)).toBe(value);
     });
 

--- a/apps/api/src/jobs/__tests__/import-processor.test.ts
+++ b/apps/api/src/jobs/__tests__/import-processor.test.ts
@@ -1,6 +1,7 @@
 import {beforeEach, describe, expect, it} from 'vitest';
 import {factories, getPrismaClient} from '../../../../../test/helpers';
 import {ContactService} from '../../services/ContactService.js';
+import {coerceCustomValue} from '../import-processor.js';
 
 /**
  * Tests for Contact Import Processor - Subscription Status Preservation
@@ -276,6 +277,28 @@ describe('Contact Import - Subscription Status Preservation', () => {
       expect(data?.plan).toBe('pro'); // Preserved
       expect(data?.lastName).toBe('Doe'); // New
       expect(data?.company).toBe('Acme Inc'); // New
+    });
+  });
+});
+
+describe('coerceCustomValue', () => {
+  describe('boolean coercion', () => {
+    it.each(['true', 'TRUE', 'True', ' true ', '1', 'yes', 'YES', 'Yes'])('coerces %j to true', value => {
+      expect(coerceCustomValue(value)).toBe(true);
+    });
+
+    it.each(['false', 'FALSE', 'False', ' false ', '0', 'no', 'NO', 'No'])('coerces %j to false', value => {
+      expect(coerceCustomValue(value)).toBe(false);
+    });
+  });
+
+  describe('passthrough', () => {
+    it.each(['Alice', 'true!', 'yesno', 'maybe', '42', '3.14', '01234'])('leaves %j as a string', value => {
+      expect(coerceCustomValue(value)).toBe(value);
+    });
+
+    it('leaves empty string as empty string', () => {
+      expect(coerceCustomValue('')).toBe('');
     });
   });
 });

--- a/apps/api/src/jobs/__tests__/import-processor.test.ts
+++ b/apps/api/src/jobs/__tests__/import-processor.test.ts
@@ -283,11 +283,11 @@ describe('Contact Import - Subscription Status Preservation', () => {
 
 describe('coerceCustomValue', () => {
   describe('boolean coercion', () => {
-    it.each(['true', 'TRUE', 'True', ' true ', '1', 'yes', 'YES', 'Yes'])('coerces %j to true', value => {
+    it.each(['true', 'TRUE', 'True', ' true ', 'yes', 'YES', 'Yes'])('coerces %j to true', value => {
       expect(coerceCustomValue(value)).toBe(true);
     });
 
-    it.each(['false', 'FALSE', 'False', ' false ', '0', 'no', 'NO', 'No'])('coerces %j to false', value => {
+    it.each(['false', 'FALSE', 'False', ' false ', 'no', 'NO', 'No'])('coerces %j to false', value => {
       expect(coerceCustomValue(value)).toBe(false);
     });
   });
@@ -300,6 +300,8 @@ describe('coerceCustomValue', () => {
       [' 42 ', 42],
       ['0.5', 0.5],
       ['-0.25', -0.25],
+      ['0', 0],
+      ['1', 1],
     ])('coerces %j to %j', (value, expected) => {
       expect(coerceCustomValue(value)).toBe(expected);
     });
@@ -310,14 +312,6 @@ describe('coerceCustomValue', () => {
         expect(coerceCustomValue(value)).toBe(value);
       },
     );
-
-    it('keeps boolean precedence: "1" stays boolean true, not number 1', () => {
-      expect(coerceCustomValue('1')).toBe(true);
-    });
-
-    it('keeps boolean precedence: "0" stays boolean false, not number 0', () => {
-      expect(coerceCustomValue('0')).toBe(false);
-    });
 
     it('"1.0" is a number (does not match the boolean truthy set)', () => {
       expect(coerceCustomValue('1.0')).toBe(1);

--- a/apps/api/src/jobs/import-processor.ts
+++ b/apps/api/src/jobs/import-processor.ts
@@ -221,21 +221,23 @@ function isValidEmail(email: string): boolean {
   return emailRegex.test(email);
 }
 
-// `0` and `1` are intentionally absent: in custom columns they are far more
-// often counts/ids/quantities than boolean flags, so they fall through to
-// numeric coercion below. The reserved `subscribed` column has its own
-// parser above that still accepts `1`/`0` as booleans.
+// Values considered as boolean during import.
+// Numbers (0, 1) are intentionally absent.
 const BOOLEAN_TRUE = new Set(['true', 'yes']);
 const BOOLEAN_FALSE = new Set(['false', 'no']);
-// Strict integer-or-decimal pattern. Rejects leading zeros (preserves IDs,
-// zips, phone numbers), scientific notation, `+` prefix, and `.5` / `42.`.
+
+// Strict integer-or-decimal number detection pattern.
+// Valid: 0, 42, -42, 3.14
+// Rejected: 007, +42, 1.2.3, 1e5
 const NUMERIC_RE = /^-?(0|[1-9]\d*)(\.\d+)?$/;
 
 /**
- * Coerce a raw CSV cell to its natural JSON primitive so post-import type
- * inference (ContactService.getAvailableFields) can detect booleans and
- * numbers on custom fields. Values that match neither recogniser are
+ * Coerces a raw string into its most natural primitive type: `boolean`,
+ * `number`, or `string`. Values that match neither are
  * returned unchanged.
+ *
+ * @param value The raw string to coerce.
+ * @returns The coerced value as `boolean`, `number`, or `string`.
  */
 export function coerceCustomValue(value: string): string | boolean | number {
   const trimmed = value.trim();

--- a/apps/api/src/jobs/import-processor.ts
+++ b/apps/api/src/jobs/import-processor.ts
@@ -123,7 +123,11 @@ export function createImportWorker() {
 
               // Extract custom data (all fields except email and subscribed)
               const {email: _, subscribed: __, ...customData} = record;
-              const data = Object.keys(customData).length > 0 ? customData : undefined;
+              const customEntries = Object.entries(customData);
+              const data =
+                customEntries.length > 0
+                  ? Object.fromEntries(customEntries.map(([k, v]) => [k, coerceCustomValue(v)]))
+                  : undefined;
 
               // Check if contact exists before upserting
               const existingContact = await ContactService.findByEmail(projectId, email);
@@ -215,4 +219,20 @@ export function createImportWorker() {
 function isValidEmail(email: string): boolean {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
+}
+
+const BOOLEAN_TRUE = new Set(['true', '1', 'yes']);
+const BOOLEAN_FALSE = new Set(['false', '0', 'no']);
+
+/**
+ * Coerce a raw CSV cell to its natural JSON primitive so post-import type
+ * inference (ContactService.getAvailableFields) can detect booleans on custom
+ * fields the same way it already does for the reserved `subscribed` column.
+ * Values outside the recognised keyword set are returned unchanged.
+ */
+export function coerceCustomValue(value: string): string | boolean {
+  const lower = value.trim().toLowerCase();
+  if (BOOLEAN_TRUE.has(lower)) return true;
+  if (BOOLEAN_FALSE.has(lower)) return false;
+  return value;
 }

--- a/apps/api/src/jobs/import-processor.ts
+++ b/apps/api/src/jobs/import-processor.ts
@@ -221,8 +221,12 @@ function isValidEmail(email: string): boolean {
   return emailRegex.test(email);
 }
 
-const BOOLEAN_TRUE = new Set(['true', '1', 'yes']);
-const BOOLEAN_FALSE = new Set(['false', '0', 'no']);
+// `0` and `1` are intentionally absent: in custom columns they are far more
+// often counts/ids/quantities than boolean flags, so they fall through to
+// numeric coercion below. The reserved `subscribed` column has its own
+// parser above that still accepts `1`/`0` as booleans.
+const BOOLEAN_TRUE = new Set(['true', 'yes']);
+const BOOLEAN_FALSE = new Set(['false', 'no']);
 // Strict integer-or-decimal pattern. Rejects leading zeros (preserves IDs,
 // zips, phone numbers), scientific notation, `+` prefix, and `.5` / `42.`.
 const NUMERIC_RE = /^-?(0|[1-9]\d*)(\.\d+)?$/;
@@ -230,9 +234,8 @@ const NUMERIC_RE = /^-?(0|[1-9]\d*)(\.\d+)?$/;
 /**
  * Coerce a raw CSV cell to its natural JSON primitive so post-import type
  * inference (ContactService.getAvailableFields) can detect booleans and
- * numbers on custom fields the same way it already does for the reserved
- * `subscribed` column. Values that match neither recogniser are returned
- * unchanged.
+ * numbers on custom fields. Values that match neither recogniser are
+ * returned unchanged.
  */
 export function coerceCustomValue(value: string): string | boolean | number {
   const trimmed = value.trim();

--- a/apps/api/src/jobs/import-processor.ts
+++ b/apps/api/src/jobs/import-processor.ts
@@ -223,16 +223,22 @@ function isValidEmail(email: string): boolean {
 
 const BOOLEAN_TRUE = new Set(['true', '1', 'yes']);
 const BOOLEAN_FALSE = new Set(['false', '0', 'no']);
+// Strict integer-or-decimal pattern. Rejects leading zeros (preserves IDs,
+// zips, phone numbers), scientific notation, `+` prefix, and `.5` / `42.`.
+const NUMERIC_RE = /^-?(0|[1-9]\d*)(\.\d+)?$/;
 
 /**
  * Coerce a raw CSV cell to its natural JSON primitive so post-import type
- * inference (ContactService.getAvailableFields) can detect booleans on custom
- * fields the same way it already does for the reserved `subscribed` column.
- * Values outside the recognised keyword set are returned unchanged.
+ * inference (ContactService.getAvailableFields) can detect booleans and
+ * numbers on custom fields the same way it already does for the reserved
+ * `subscribed` column. Values that match neither recogniser are returned
+ * unchanged.
  */
-export function coerceCustomValue(value: string): string | boolean {
-  const lower = value.trim().toLowerCase();
+export function coerceCustomValue(value: string): string | boolean | number {
+  const trimmed = value.trim();
+  const lower = trimmed.toLowerCase();
   if (BOOLEAN_TRUE.has(lower)) return true;
   if (BOOLEAN_FALSE.has(lower)) return false;
+  if (NUMERIC_RE.test(trimmed)) return Number(trimmed);
   return value;
 }

--- a/apps/wiki/content/docs/guides/importing-contacts.mdx
+++ b/apps/wiki/content/docs/guides/importing-contacts.mdx
@@ -37,6 +37,8 @@ In this example, every imported contact ends up with `data.firstName`, `data.pla
 - **Email column**: must be present and valid. Rows with missing or invalid emails are reported back as errors.
 - **Reserved column names**: `id`, `subscribed`, `createdAt`, `updatedAt`, and the auto-generated URL variables (`unsubscribeUrl`, etc.) are silently filtered out. Don't include them as columns.
 - **Date columns**: use ISO 8601 (`2026-05-06T12:00:00Z`) so they're typed as dates and become usable with `within` / `olderThan` segment operators.
+- **Boolean columns**: `true`, `false`, `yes`, `no` (case-insensitive) are stored as booleans and get the boolean toggle in segment filters.
+- **Numeric columns**: plain integers and decimals (`42`, `3.14`) are stored as numbers and become usable with `gt` / `lt` segment operators. Leading-zero values (`01234`), `+`-prefixed numbers, and scientific notation stay strings so IDs, zip codes, and phone numbers aren't corrupted.
 - **Existing contacts**: if a row's email matches an existing contact, the import **updates** the contact (merging the CSV's columns into `data`). It doesn't create a duplicate or overwrite the whole record.
 
 ## Importing your CSV


### PR DESCRIPTION
## Description

Custom columns in CSV contact imports were always strings, regardless of whether the cell contained `true`/`false`, a number, or free text.

Only the reserved `subscribed` column was previously coerced; this PR extends the same idea to all custom columns via a small `coerceCustomValue` helper in `apps/api/src/jobs/import-processor.ts`:

 - **Boolean coercion** mirrors the truthy/falsy keyword sets already used for `subscribed`: `true`/`yes` and `false`/`no`. Values outside the keyword set pass through unchanged so names or IDs are not corrupted into `false`.
 - **Numeric coercion** uses a strict integer-or-decimal regex rather than `Number()`, so string-shaped numerics that users intend as identifiers stay strings: leading-zero IDs (`"01234"`), zip codes, phone numbers, and signed or scientific-notation forms (`"+42"`, `"1e10"`, `".5"`, `"42."`).
 - **`"0"` and `"1"`** are treated as numbers, not booleans, in custom columns. In practice these values are far more often counts, quantities, or ids than flags, and coercing them to booleans hid the numeric operators for those fields.

 > This change was implemented with AI assistance (Claude Code) and verified
 > manually by importing a CSV through the dashboard and inspecting the resulting
 > contact in the web UI.

## Type of Change

 - [x] `fix:` Bug fix (PATCH version bump)

 ## Testing

**Manual end-to-end tested** using the csv file:

```csv
email,locale,booltest,numbertest
my@email.com,en,true,0
example@example.com,en,false,1
test@test.com,en,True,123
```

1. Uploaded it into the CSV contact import.
2. Verified that the contacts have the custom data attached
3. Verified the contact data types via Settings UI

See screenshot below.

### Screenshots

#### 01: Contacts imported

<img width="1215" height="452" alt="01-contacts-imported" src="https://github.com/user-attachments/assets/b3fa181b-b6bc-4ea1-a7dd-438ae2fa719e" />

#### 02: Contacts data
<img width="804" height="465" alt="02-contact-data" src="https://github.com/user-attachments/assets/ad4daac0-234b-477d-a57a-0c15555523cb" />

#### 03: Contacts data types

<img width="930" height="526" alt="03-data-types" src="https://github.com/user-attachments/assets/4b1d8fbb-f4d0-4952-943d-b6e1961a1bbd" />

 ## Checklist

 - [x] PR title follows conventional commits format
 - [x] Code builds successfully
 - [x] Tests pass locally
 - [X] Documentation updated (if needed)

 ## Related Issues

 Closes #390