### PR TITLE
docs(env): sync env example files, fix CLAUDE.md drift, add process rule

### DIFF
--- a/.env.self-host.example
+++ b/.env.self-host.example
@@ -8,6 +8,15 @@
 DB_PASSWORD=changeme123
 JWT_SECRET=
 
+# The variables below are auto-configured by Docker Compose using DB_PASSWORD
+# above. Override only when pointing at an external database / Redis or when
+# running the app outside of the bundled Compose stack.
+# NODE_ENV=production
+# DATABASE_URL=postgresql://plunk:${DB_PASSWORD}@postgres:5432/plunk
+# DIRECT_DATABASE_URL=postgresql://plunk:${DB_PASSWORD}@postgres:5432/plunk
+# REDIS_URL=redis://redis:6379
+# PORT=8080
+
 # ========================================
 # REQUIRED: Domains
 # ========================================
@@ -68,6 +77,16 @@ GOOGLE_OAUTH_CLIENT=
 GOOGLE_OAUTH_SECRET=
 
 # ========================================
+# OPTIONAL: Stripe (Billing)
+# ========================================
+# Enables paid billing. All variables must be set together for billing to activate.
+STRIPE_SK=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_ONBOARDING=
+STRIPE_PRICE_EMAIL_USAGE=
+STRIPE_METER_EVENT_NAME=emails
+
+# ========================================
 # OPTIONAL: File Storage (Minio)
 # ========================================
 # Minio is included by default in Docker Compose
@@ -86,6 +105,14 @@ S3_ACCESS_KEY_SECRET=plunkminiopass
 S3_BUCKET=uploads
 S3_PUBLIC_URL=http://localhost:9000/uploads
 S3_FORCE_PATH_STYLE=true
+
+# ========================================
+# OPTIONAL: Attachments
+# ========================================
+# Limits applied to attachments on transactional emails.
+# AWS SES caps total message size at 40 MB; the defaults below leave headroom.
+# MAX_ATTACHMENT_SIZE_MB=10
+# MAX_ATTACHMENTS_COUNT=10
 
 # ========================================
 # OPTIONAL: Notifications (ntfy.sh)
@@ -116,6 +143,11 @@ NTFY_URL=http://ntfy/plunk-notifications
 # SMTP domain - Required if using Traefik acme.json with multiple certificates
 # Optional if using PEM files
 SMTP_DOMAIN=smtp.example.com
+
+# Explicitly enable SMTP features in the UI. Automatically enabled when
+# SMTP_DOMAIN is set to a non-localhost value in production.
+# Default: false
+# SMTP_ENABLED=false
 
 # SMTP Ports (defaults work for most setups)
 # PORT_SECURE=465         # SMTPS (implicit TLS)
@@ -151,6 +183,25 @@ SMTP_DOMAIN=smtp.example.com
 # Useful for private instances or when you want to manually manage users
 # Default: false
 # DISABLE_SIGNUPS=false
+
+# When enabled (true), validates emails on signup — checks for disposable
+# domains, plus-addressing, domain existence, and MX records.
+# Default: false
+# VERIFY_EMAIL_ON_SIGNUP=false
+
+# ========================================
+# OPTIONAL: Phishing Detection
+# ========================================
+# Plunk can use an LLM (via OpenRouter) to detect phishing emails before sending.
+# When enabled, a random sample of outgoing emails is analyzed and projects can
+# be auto-disabled if confidence exceeds the threshold or the cumulative count
+# is reached within the window.
+# OPENROUTER_API_KEY=
+# OPENROUTER_MODEL=anthropic/claude-3-haiku
+# PHISHING_DETECTION_SAMPLE_RATE=0.1
+# PHISHING_CONFIDENCE_THRESHOLD=95
+# PHISHING_CUMULATIVE_THRESHOLD=3
+# PHISHING_CUMULATIVE_WINDOW_MS=3600000
 
 # ========================================
 # OPTIONAL: SES Sending Rate

--- a/.env.self-host.example
+++ b/.env.self-host.example
@@ -8,15 +8,6 @@
 DB_PASSWORD=changeme123
 JWT_SECRET=
 
-# The variables below are auto-configured by Docker Compose using DB_PASSWORD
-# above. Override only when pointing at an external database / Redis or when
-# running the app outside of the bundled Compose stack.
-# NODE_ENV=production
-# DATABASE_URL=postgresql://plunk:${DB_PASSWORD}@postgres:5432/plunk
-# DIRECT_DATABASE_URL=postgresql://plunk:${DB_PASSWORD}@postgres:5432/plunk
-# REDIS_URL=redis://redis:6379
-# PORT=8080
-
 # ========================================
 # REQUIRED: Domains
 # ========================================
@@ -77,16 +68,6 @@ GOOGLE_OAUTH_CLIENT=
 GOOGLE_OAUTH_SECRET=
 
 # ========================================
-# OPTIONAL: Stripe (Billing)
-# ========================================
-# Enables paid billing. All variables must be set together for billing to activate.
-STRIPE_SK=
-STRIPE_WEBHOOK_SECRET=
-STRIPE_PRICE_ONBOARDING=
-STRIPE_PRICE_EMAIL_USAGE=
-STRIPE_METER_EVENT_NAME=emails
-
-# ========================================
 # OPTIONAL: File Storage (Minio)
 # ========================================
 # Minio is included by default in Docker Compose
@@ -105,14 +86,6 @@ S3_ACCESS_KEY_SECRET=plunkminiopass
 S3_BUCKET=uploads
 S3_PUBLIC_URL=http://localhost:9000/uploads
 S3_FORCE_PATH_STYLE=true
-
-# ========================================
-# OPTIONAL: Attachments
-# ========================================
-# Limits applied to attachments on transactional emails.
-# AWS SES caps total message size at 40 MB; the defaults below leave headroom.
-# MAX_ATTACHMENT_SIZE_MB=10
-# MAX_ATTACHMENTS_COUNT=10
 
 # ========================================
 # OPTIONAL: Notifications (ntfy.sh)
@@ -143,11 +116,6 @@ NTFY_URL=http://ntfy/plunk-notifications
 # SMTP domain - Required if using Traefik acme.json with multiple certificates
 # Optional if using PEM files
 SMTP_DOMAIN=smtp.example.com
-
-# Explicitly enable SMTP features in the UI. Automatically enabled when
-# SMTP_DOMAIN is set to a non-localhost value in production.
-# Default: false
-# SMTP_ENABLED=false
 
 # SMTP Ports (defaults work for most setups)
 # PORT_SECURE=465         # SMTPS (implicit TLS)
@@ -183,25 +151,6 @@ SMTP_DOMAIN=smtp.example.com
 # Useful for private instances or when you want to manually manage users
 # Default: false
 # DISABLE_SIGNUPS=false
-
-# When enabled (true), validates emails on signup — checks for disposable
-# domains, plus-addressing, domain existence, and MX records.
-# Default: false
-# VERIFY_EMAIL_ON_SIGNUP=false
-
-# ========================================
-# OPTIONAL: Phishing Detection
-# ========================================
-# Plunk can use an LLM (via OpenRouter) to detect phishing emails before sending.
-# When enabled, a random sample of outgoing emails is analyzed and projects can
-# be auto-disabled if confidence exceeds the threshold or the cumulative count
-# is reached within the window.
-# OPENROUTER_API_KEY=
-# OPENROUTER_MODEL=anthropic/claude-3-haiku
-# PHISHING_DETECTION_SAMPLE_RATE=0.1
-# PHISHING_CONFIDENCE_THRESHOLD=95
-# PHISHING_CUMULATIVE_THRESHOLD=3
-# PHISHING_CUMULATIVE_WINDOW_MS=3600000
 
 # ========================================
 # OPTIONAL: SES Sending Rate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Required for builds and deployment (see turbo.json and .env.example):
   - `OPENROUTER_API_KEY` - API key for OpenRouter (enables phishing detection)
   - `OPENROUTER_MODEL` (default: anthropic/claude-3-haiku) - LLM model to use for content analysis
   - `PHISHING_DETECTION_SAMPLE_RATE` (default: 0.1) - Percentage of emails to check (0.0-1.0, e.g., 0.1 = 10%)
-  - `PHISHING_CONFIDENCE_THRESHOLD` (default: 85) - Minimum confidence percentage (0-100) to auto-disable project for single detection
+  - `PHISHING_CONFIDENCE_THRESHOLD` (default: 95) - Minimum confidence percentage (0-100) to auto-disable project for single detection
   - `PHISHING_CUMULATIVE_THRESHOLD` (default: 3) - Number of phishing detections within time window to trigger auto-disable
   - `PHISHING_CUMULATIVE_WINDOW_MS` (default: 3600000) - Time window in milliseconds for cumulative tracking (default 1 hour)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,21 @@ Required for builds and deployment (see turbo.json and .env.example):
 - **Frontend Variables**: Next.js apps use `NEXT_PUBLIC_*` prefixed variables that are embedded at build time for
   client-side access
 
+## Environment Variable Changes
+
+When you add, rename, remove, or change the default/behaviour of any environment variable, you MUST update all THREE of the following in the same change:
+
+1. `apps/api/.env.example` — local development defaults
+2. `.env.self-host.example` — self-hosting / production template
+3. `apps/wiki/content/docs/self-hosting/environment-variables.mdx` — user-facing reference
+
+Rules:
+
+- If the variable already exists in any file, **modify** its line/row/description — do not duplicate or leave a stale entry.
+- Keep section/category names consistent across all three files (e.g. "AWS SES", "Phishing Detection").
+- For dev-only or self-host-only variables, still mention them in the wiki and note the scope; only skip the example file where the variable is genuinely never applicable.
+- When in doubt about whether a variable belongs in `apps/api/.env.example` (development), include it commented out with a short note.
+
 ## Plugins
 
 There are two plugins installed for you to use.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,6 +8,8 @@
 # ==============================================================================
 NODE_ENV=development
 JWT_SECRET=hBx9Xh8J6KOMAGAsSjvcZJBT5TWyIkFX
+# Port the API server listens on (default: 8080)
+# PORT=8080
 
 # ==============================================================================
 # Application URLs
@@ -25,6 +27,8 @@ LANDING_URI=http://localhost:4000
 # ==============================================================================
 # API key for authenticating with the Plunk API (obtained from dashboard)
 PLUNK_API_KEY=
+# From address used for platform notification emails (project disabled, billing limits, etc.)
+# PLUNK_FROM_ADDRESS=
 
 # ==============================================================================
 # Database & Redis
@@ -85,3 +89,46 @@ STRIPE_METER_EVENT_NAME=emails # Meter event name (API key from your Stripe mete
 # Set to 'false' to disable automatic project suspension (useful for self-hosters who manage manually)
 # Default: true (automatic project disabling enabled)
 # AUTO_PROJECT_DISABLE=true
+
+# ==============================================================================
+# Notifications (Optional - system notifications via ntfy)
+# ==============================================================================
+# ntfy topic URL for internal system notifications (e.g. project disabled, billing limits).
+# When unset, ntfy notifications are disabled.
+# Examples:
+#   - Public ntfy.sh: https://ntfy.sh/your-unique-topic-name
+#   - Self-hosted:    https://your-ntfy-server.com/your-topic
+# NTFY_URL=
+
+# ==============================================================================
+# Attachments (Optional)
+# ==============================================================================
+# Limits applied to attachments on transactional emails.
+# AWS SES caps total message size at 40 MB; the defaults below leave headroom.
+# MAX_ATTACHMENT_SIZE_MB=10
+# MAX_ATTACHMENTS_COUNT=10
+
+# ==============================================================================
+# User Management (Optional)
+# ==============================================================================
+# When 'true', the signup endpoint rejects new user registrations.
+# Default: false
+# DISABLE_SIGNUPS=false
+# When 'true', validates emails on signup (disposable domains, plus-addressing,
+# domain existence, MX records).
+# Default: false
+# VERIFY_EMAIL_ON_SIGNUP=false
+
+# ==============================================================================
+# Phishing Detection (Optional - AI-powered phishing scan via OpenRouter)
+# ==============================================================================
+# When OPENROUTER_API_KEY is set, a random sample of outgoing emails is
+# analyzed by an LLM. Projects can be auto-disabled if a single email exceeds
+# PHISHING_CONFIDENCE_THRESHOLD, or if PHISHING_CUMULATIVE_THRESHOLD emails are
+# flagged within PHISHING_CUMULATIVE_WINDOW_MS.
+# OPENROUTER_API_KEY=
+# OPENROUTER_MODEL=anthropic/claude-3-haiku
+# PHISHING_DETECTION_SAMPLE_RATE=0.1
+# PHISHING_CONFIDENCE_THRESHOLD=95
+# PHISHING_CUMULATIVE_THRESHOLD=3
+# PHISHING_CUMULATIVE_WINDOW_MS=3600000

--- a/apps/wiki/content/docs/self-hosting/environment-variables.mdx
+++ b/apps/wiki/content/docs/self-hosting/environment-variables.mdx
@@ -36,6 +36,7 @@ Set your subdomains here. The application automatically derives all internal and
 | `AWS_SES_SECRET_ACCESS_KEY`         | Yes      | AWS secret access key for SES.                                                                                                                   | `wJalr...`                                      |
 | `SES_CONFIGURATION_SET`             | No       | SES configuration set name used for open/click tracking.                                                                                         | `plunk-configuration-set` (default)             |
 | `SES_CONFIGURATION_SET_NO_TRACKING` | No       | A second SES configuration set without tracking. When set, projects can toggle email tracking on/off. If omitted, the tracking toggle is hidden. | `plunk-no-tracking-configuration-set` (default) |
+| `MAIL_FROM_SUBDOMAIN`               | No       | Subdomain prefix used when constructing the MAIL FROM hostname for a verified domain (e.g. with default `plunk` and domain `yourdomain.com`, the MAIL FROM is `plunk.yourdomain.com`). Override when the default subdomain is already in use (e.g. by an R2/CDN custom domain), since the MAIL FROM hostname needs MX + TXT records that can't coexist with a CNAME. | `plunk`                                         |
 
 ## Storage (Minio)
 
@@ -129,6 +130,14 @@ Plunk bundles a self-hosted [ntfy](https://ntfy.sh) server for internal system n
 | ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `AUTO_PROJECT_DISABLE`        | No       | When `true`, projects are automatically suspended when bounce or complaint rate thresholds are exceeded. Set to `false` to manage project status manually. | `true`  |
 | `EMAIL_RATE_LIMIT_PER_SECOND` | No       | Override the email sending rate limit. If not set, Plunk automatically fetches the quota from your AWS SES account.                                        | —       |
+
+## Advanced
+
+Variables for unusual deployments. The defaults work for the standard Docker Compose setup — only change these if you know you need to.
+
+| Variable     | Required | Description                                                                                                              | Default |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `NGINX_PORT` | No       | Host port the bundled Nginx reverse proxy binds to. Override when port 80/443 is already in use on the host (e.g. running behind another reverse proxy that forwards to a different port). | `80`    |
 
 ## Phishing Detection
 


### PR DESCRIPTION
## Description

Three sources describe Plunk's environment variables and they had drifted apart:

- `apps/api/.env.example` (development defaults)
- `.env.self-host.example` (production/self-host template)
- `apps/wiki/content/docs/self-hosting/environment-variables.mdx` (user-facing reference)

This PR brings them into parity in one shot and adds a CLAUDE.md rule so future env-var changes are required to touch all three locations.

## Type of Change

- [ ] `feat:` New feature (MINOR version bump)
- [ ] `fix:` Bug fix (PATCH version bump)
- [ ] `feat!:` Breaking change - new feature (MAJOR version bump)
- [ ] `fix!:` Breaking change - bug fix (MAJOR version bump)
- [x] `docs:` Documentation update (no version bump)
- [ ] `chore:` Maintenance/dependencies (no version bump)
- [ ] `refactor:` Code refactoring (no version bump)
- [ ] `test:` Adding tests (no version bump)
- [ ] `perf:` Performance improvement (PATCH version bump)

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully (no code changes; docs/templates only)
- [x] Tests pass locally (n/a — no code paths touched)
- [x] Documentation updated (the wiki update is part of this PR)

## Related Issues

None