### PR TITLE
feat: insert, disconnect and reconnect steps in the workflow editor

### DIFF
--- a/apps/api/src/controllers/Workflows.ts
+++ b/apps/api/src/controllers/Workflows.ts
@@ -332,6 +332,38 @@ export class Workflows {
   }
 
   /**
+   * POST /workflows/:id/transitions/:transitionId/insert-step
+   * Insert a new step in the middle of an existing transition (A -> B becomes A -> NEW -> B)
+   */
+  @Post(':id/transitions/:transitionId/insert-step')
+  @Middleware([requireAuth, requireEmailVerified])
+  @CatchAsync
+  public async insertStepOnTransition(req: Request, res: Response, _next: NextFunction) {
+    const auth = res.locals.auth;
+    const workflowId = req.params.id;
+    const transitionId = req.params.transitionId;
+    const {type, name, position, config, templateId} = req.body;
+
+    if (!workflowId || !transitionId) {
+      return res.status(400).json({error: 'Workflow ID and Transition ID are required'});
+    }
+
+    if (!type || !name || !config) {
+      return res.status(400).json({error: 'Type, name, and config are required'});
+    }
+
+    const step = await WorkflowService.insertStepOnTransition(auth.projectId!, workflowId, transitionId, {
+      type,
+      name,
+      position,
+      config,
+      templateId,
+    });
+
+    return res.status(201).json(step);
+  }
+
+  /**
    * DELETE /workflows/:id/transitions/:transitionId
    * Delete a transition
    */

--- a/apps/api/src/services/WorkflowService.ts
+++ b/apps/api/src/services/WorkflowService.ts
@@ -805,6 +805,132 @@ export class WorkflowService {
   }
 
   /**
+   * Insert a new step in the middle of an existing transition.
+   *
+   * Given `A -[t]-> B`, this creates `A -[t]-> NEW -> B` in a single transaction:
+   * the existing transition is re-pointed at the new step (keeping its condition,
+   * so a condition branch keeps its label) and a fresh transition carries the
+   * flow on to the original target.
+   *
+   * When the inserted step is itself a CONDITION, the downstream transition is
+   * attached to its first branch (`yes`) rather than left unconditional — a
+   * condition step routes exclusively by branch, so an unconditional outgoing
+   * transition would never be taken and B would be stranded.
+   *
+   * Purely additive — no step is removed and nothing becomes unreachable — so
+   * unlike splice/delete this does not need to guard against in-flight executions.
+   * An execution parked on A simply picks up the new step on its next hop.
+   */
+  public static async insertStepOnTransition(
+    projectId: string,
+    workflowId: string,
+    transitionId: string,
+    data: {
+      type: WorkflowStep['type'];
+      name: string;
+      position?: Prisma.JsonValue;
+      config: Prisma.JsonValue;
+      templateId?: string;
+    },
+  ): Promise<WorkflowStep> {
+    await this.get(projectId, workflowId);
+
+    const transition = await prisma.workflowTransition.findFirst({
+      where: {
+        id: transitionId,
+        fromStep: {workflowId, workflow: {projectId}},
+      },
+    });
+
+    if (!transition) {
+      throw new HttpException(404, 'Transition not found');
+    }
+
+    if (data.type === 'TRIGGER') {
+      throw new HttpException(400, 'A trigger step cannot be inserted into the flow.');
+    }
+
+    // EXIT terminates a path, so it can never carry the flow on to the original
+    // target — inserting one here would silently orphan everything below it.
+    if (data.type === 'EXIT') {
+      throw new HttpException(
+        400,
+        'An exit step ends the flow and cannot be inserted between two steps. ' +
+          'Disconnect the steps first, then add the exit step.',
+      );
+    }
+
+    return prisma.$transaction(async tx => {
+      const newStep = await tx.workflowStep.create({
+        data: {
+          workflowId,
+          type: data.type,
+          name: data.name,
+          position: toPrismaJson(data.position ?? {x: 0, y: 0}),
+          config: toPrismaJson(data.config),
+          templateId: data.templateId,
+        },
+      });
+
+      // Re-point the original transition (keeps its condition/priority, so the
+      // branch it belongs to is preserved) at the new step.
+      await tx.workflowTransition.update({
+        where: {id: transitionId},
+        data: {toStepId: newStep.id},
+      });
+
+      await tx.workflowTransition.create({
+        data: {
+          fromStepId: newStep.id,
+          toStepId: transition.toStepId,
+          // A freshly created condition has no config yet, which the builder reads
+          // as the default binary yes/no pair — so `yes` is its first branch.
+          condition: data.type === 'CONDITION' ? toPrismaJson({branch: 'yes'}) : Prisma.JsonNull,
+          priority: 0,
+        },
+      });
+
+      return newStep;
+    });
+  }
+
+  /**
+   * Whether `targetStepId` is reachable by following transitions from `fromStepId`.
+   * Used to keep the graph acyclic when new connections are made.
+   */
+  private static async reaches(workflowId: string, fromStepId: string, targetStepId: string): Promise<boolean> {
+    if (fromStepId === targetStepId) {
+      return true;
+    }
+
+    const allSteps = await prisma.workflowStep.findMany({
+      where: {workflowId},
+      select: {id: true, outgoingTransitions: {select: {toStepId: true}}},
+    });
+
+    const adjacency = new Map(allSteps.map(s => [s.id, s.outgoingTransitions.map(t => t.toStepId)]));
+
+    const seen = new Set<string>([fromStepId]);
+    const queue = [fromStepId];
+
+    while (queue.length > 0) {
+      const currentId = queue.shift()!;
+
+      for (const nextId of adjacency.get(currentId) ?? []) {
+        if (nextId === targetStepId) {
+          return true;
+        }
+        if (!seen.has(nextId)) {
+          seen.add(nextId);
+          queue.push(nextId);
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Create a transition between two steps
    */
   public static async createTransition(
@@ -817,6 +943,10 @@ export class WorkflowService {
       priority?: number;
     },
   ): Promise<WorkflowTransition> {
+    if (data.fromStepId === data.toStepId) {
+      throw new HttpException(400, 'A step cannot be connected to itself');
+    }
+
     // Verify both steps belong to the workflow
     const steps = await prisma.workflowStep.findMany({
       where: {
@@ -831,6 +961,11 @@ export class WorkflowService {
     }
 
     const fromStep = steps.find(s => s.id === data.fromStepId);
+
+    // An exit step terminates the path it is on.
+    if (fromStep?.type === 'EXIT') {
+      throw new HttpException(400, 'An exit step ends the flow and cannot be connected to another step');
+    }
 
     // For CONDITION steps, validate that this branch doesn't already have a transition
     if (fromStep?.type === 'CONDITION' && data.condition) {
@@ -857,6 +992,25 @@ export class WorkflowService {
           );
         }
       }
+    } else if (fromStep?.type !== 'CONDITION') {
+      // Every other step type routes to exactly one next step. A second outgoing
+      // transition would make the next hop ambiguous at execution time.
+      const existingOutgoing = await prisma.workflowTransition.findFirst({
+        where: {fromStepId: data.fromStepId},
+      });
+
+      if (existingOutgoing) {
+        throw new HttpException(
+          400,
+          `"${fromStep?.name}" already leads to another step. Disconnect it first, or use a condition step to branch.`,
+        );
+      }
+    }
+
+    // Reject connections that would close a loop. Nothing bounds how many times
+    // an execution may traverse the graph, so a cycle would run indefinitely.
+    if (await this.reaches(workflowId, data.toStepId, data.fromStepId)) {
+      throw new HttpException(400, 'This connection would create a loop in the workflow');
     }
 
     const newTransition = await prisma.workflowTransition.create({

--- a/apps/api/src/services/__tests__/WorkflowService.test.ts
+++ b/apps/api/src/services/__tests__/WorkflowService.test.ts
@@ -754,6 +754,67 @@ describe('WorkflowService', () => {
       expect(noTransition.condition).toEqual({branch: 'no'});
     });
 
+    it('should reject a second outgoing transition from a non-condition step', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const step1 = await factories.createWorkflowStep({workflowId: workflow.id, type: WorkflowStepType.DELAY});
+      const step2 = await factories.createWorkflowStep({workflowId: workflow.id});
+      const step3 = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      await WorkflowService.createTransition(projectId, workflow.id, {
+        fromStepId: step1.id,
+        toStepId: step2.id,
+      });
+
+      await expect(
+        WorkflowService.createTransition(projectId, workflow.id, {
+          fromStepId: step1.id,
+          toStepId: step3.id,
+        }),
+      ).rejects.toThrow(/already leads to another step/i);
+    });
+
+    it('should reject connecting a step to itself', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const step = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      await expect(
+        WorkflowService.createTransition(projectId, workflow.id, {
+          fromStepId: step.id,
+          toStepId: step.id,
+        }),
+      ).rejects.toThrow(/cannot be connected to itself/i);
+    });
+
+    it('should reject an outgoing transition from an EXIT step', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const exitStep = await factories.createWorkflowStep({workflowId: workflow.id, type: WorkflowStepType.EXIT});
+      const step2 = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      await expect(
+        WorkflowService.createTransition(projectId, workflow.id, {
+          fromStepId: exitStep.id,
+          toStepId: step2.id,
+        }),
+      ).rejects.toThrow(/exit step ends the flow/i);
+    });
+
+    it('should reject a transition that would close a loop', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const stepA = await factories.createWorkflowStep({workflowId: workflow.id, type: WorkflowStepType.DELAY});
+      const stepB = await factories.createWorkflowStep({workflowId: workflow.id, type: WorkflowStepType.DELAY});
+      const stepC = await factories.createWorkflowStep({workflowId: workflow.id, type: WorkflowStepType.DELAY});
+
+      await prisma.workflowTransition.create({data: {fromStepId: stepA.id, toStepId: stepB.id}});
+      await prisma.workflowTransition.create({data: {fromStepId: stepB.id, toStepId: stepC.id}});
+
+      await expect(
+        WorkflowService.createTransition(projectId, workflow.id, {
+          fromStepId: stepC.id,
+          toStepId: stepA.id,
+        }),
+      ).rejects.toThrow(/loop/i);
+    });
+
     it('should throw 404 when steps not found', async () => {
       const workflow = await factories.createWorkflow({projectId});
 
@@ -763,6 +824,141 @@ describe('WorkflowService', () => {
           toStepId: 'non-existent-2',
         }),
       ).rejects.toThrow('One or both steps not found');
+    });
+  });
+
+  describe('insertStepOnTransition', () => {
+    it('should split a transition into two around the new step', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const stepA = await factories.createWorkflowStep({workflowId: workflow.id});
+      const stepB = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      const transition = await prisma.workflowTransition.create({
+        data: {fromStepId: stepA.id, toStepId: stepB.id},
+      });
+
+      const newStep = await WorkflowService.insertStepOnTransition(projectId, workflow.id, transition.id, {
+        type: WorkflowStepType.DELAY,
+        name: 'Inserted delay',
+        config: {},
+      });
+
+      const original = await prisma.workflowTransition.findUnique({where: {id: transition.id}});
+      expect(original?.toStepId).toBe(newStep.id);
+
+      const outgoing = await prisma.workflowTransition.findMany({where: {fromStepId: newStep.id}});
+      expect(outgoing).toHaveLength(1);
+      expect(outgoing[0]?.toStepId).toBe(stepB.id);
+    });
+
+    it('should preserve the branch condition on the upstream transition', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const conditionStep = await factories.createWorkflowStep({
+        workflowId: workflow.id,
+        type: WorkflowStepType.CONDITION,
+      });
+      const stepB = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      const transition = await prisma.workflowTransition.create({
+        data: {fromStepId: conditionStep.id, toStepId: stepB.id, condition: {branch: 'yes'}, priority: 3},
+      });
+
+      const newStep = await WorkflowService.insertStepOnTransition(projectId, workflow.id, transition.id, {
+        type: WorkflowStepType.SEND_EMAIL,
+        name: 'Inserted email',
+        config: {},
+      });
+
+      const original = await prisma.workflowTransition.findUnique({where: {id: transition.id}});
+      expect(original?.condition).toEqual({branch: 'yes'});
+      expect(original?.priority).toBe(3);
+
+      // The transition carrying the flow onwards is unconditional
+      const outgoing = await prisma.workflowTransition.findMany({where: {fromStepId: newStep.id}});
+      expect(outgoing[0]?.condition).toBeNull();
+    });
+
+    it('should attach the downstream step to the first branch when inserting a CONDITION', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const stepA = await factories.createWorkflowStep({workflowId: workflow.id});
+      const stepB = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      const transition = await prisma.workflowTransition.create({
+        data: {fromStepId: stepA.id, toStepId: stepB.id},
+      });
+
+      const conditionStep = await WorkflowService.insertStepOnTransition(projectId, workflow.id, transition.id, {
+        type: WorkflowStepType.CONDITION,
+        name: 'Inserted condition',
+        config: {},
+      });
+
+      // A condition routes only by branch, so B has to hang off one of them
+      const outgoing = await prisma.workflowTransition.findMany({where: {fromStepId: conditionStep.id}});
+      expect(outgoing).toHaveLength(1);
+      expect(outgoing[0]?.toStepId).toBe(stepB.id);
+      expect(outgoing[0]?.condition).toEqual({branch: 'yes'});
+    });
+
+    it('should reject inserting an EXIT step', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const stepA = await factories.createWorkflowStep({workflowId: workflow.id});
+      const stepB = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      const transition = await prisma.workflowTransition.create({
+        data: {fromStepId: stepA.id, toStepId: stepB.id},
+      });
+
+      await expect(
+        WorkflowService.insertStepOnTransition(projectId, workflow.id, transition.id, {
+          type: WorkflowStepType.EXIT,
+          name: 'Exit',
+          config: {},
+        }),
+      ).rejects.toThrow(/exit step ends the flow/i);
+
+      // Nothing was created and the original wiring is untouched
+      const original = await prisma.workflowTransition.findUnique({where: {id: transition.id}});
+      expect(original?.toStepId).toBe(stepB.id);
+    });
+
+    it('should reject inserting a TRIGGER step', async () => {
+      const workflow = await factories.createWorkflow({projectId});
+      const stepA = await factories.createWorkflowStep({workflowId: workflow.id});
+      const stepB = await factories.createWorkflowStep({workflowId: workflow.id});
+
+      const transition = await prisma.workflowTransition.create({
+        data: {fromStepId: stepA.id, toStepId: stepB.id},
+      });
+
+      await expect(
+        WorkflowService.insertStepOnTransition(projectId, workflow.id, transition.id, {
+          type: WorkflowStepType.TRIGGER,
+          name: 'Trigger',
+          config: {},
+        }),
+      ).rejects.toThrow(/trigger step cannot be inserted/i);
+    });
+
+    it('should throw 404 for a transition from another project', async () => {
+      const {project: otherProject} = await factories.createUserWithProject();
+      const otherWorkflow = await factories.createWorkflow({projectId: otherProject.id});
+      const stepA = await factories.createWorkflowStep({workflowId: otherWorkflow.id});
+      const stepB = await factories.createWorkflowStep({workflowId: otherWorkflow.id});
+
+      const transition = await prisma.workflowTransition.create({
+        data: {fromStepId: stepA.id, toStepId: stepB.id},
+      });
+
+      const workflow = await factories.createWorkflow({projectId});
+
+      await expect(
+        WorkflowService.insertStepOnTransition(projectId, workflow.id, transition.id, {
+          type: WorkflowStepType.DELAY,
+          name: 'Inserted delay',
+          config: {},
+        }),
+      ).rejects.toThrow('Transition not found');
     });
   });
 

--- a/apps/web/src/components/WorkflowBuilder.tsx
+++ b/apps/web/src/components/WorkflowBuilder.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Background,
+  type Connection,
+  ConnectionLineType,
   Controls,
   type Edge,
   Handle,
@@ -35,6 +37,7 @@ import {
 } from 'lucide-react';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import dagre from 'dagre';
+import {WorkflowEdge} from './WorkflowEdge';
 import {network} from '../lib/network';
 import {toast} from 'sonner';
 import {Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle} from '@plunk/ui';
@@ -110,6 +113,27 @@ function getExpectedBranches(config: any): string[] {
     return [...(config.branches || []).map((b: any) => b.id), 'default'];
   }
   return ['yes', 'no'];
+}
+
+/** Reads the branch id off a transition's condition, if it carries one. */
+function getTransitionBranch(condition: unknown): string | undefined {
+  if (condition && typeof condition === 'object' && 'branch' in condition) {
+    return String((condition as {branch: unknown}).branch);
+  }
+  return undefined;
+}
+
+/**
+ * Branch ids a condition step should expose a handle for: the branches its config
+ * declares, plus any branch that is already wired up. The two can drift apart if
+ * the condition was reconfigured after connections were made, and dropping a
+ * wired branch here would leave its edge pointing at a handle that doesn't exist.
+ */
+function getBranchHandles(config: any, transitions: Array<{condition: unknown}> = []): string[] {
+  const expected = getExpectedBranches(config);
+  const wired = transitions.map(t => getTransitionBranch(t.condition)).filter((b): b is string => Boolean(b));
+
+  return [...expected, ...wired.filter(b => !expected.includes(b))];
 }
 
 function getBranchLabel(config: any, branchId: string): string {
@@ -205,13 +229,31 @@ function getLayoutedElements(nodes: Node[], edges: Edge[]) {
   return {nodes: adjustedNodes, edges};
 }
 
+/**
+ * Handle ids. Every edge names its handles explicitly so a condition's branch
+ * survives the round trip through React Flow, and so connections dragged by hand
+ * report which branch they came from.
+ */
+const TARGET_HANDLE_ID = 'in';
+const SOURCE_HANDLE_ID = 'out';
+
+const HANDLE_STYLE = {
+  background: '#94a3b8',
+  width: 10,
+  height: 10,
+  border: '2px solid white',
+  boxShadow: '0 1px 3px rgba(0,0,0,0.25)',
+};
+
 // Add Step Node - appears at the end of flow paths
 function AddStepNode({data}: {data: {label: string; onClick?: () => void}}) {
   return (
     <>
       <Handle
+        id={TARGET_HANDLE_ID}
         type="target"
         position={Position.Top}
+        isConnectable={false}
         style={{
           background: '#94a3b8',
           width: 14,
@@ -246,6 +288,12 @@ function CustomNode({
     onDelete?: () => void;
     template?: {id: string; name: string};
     config?: any;
+    /**
+     * One entry per outgoing slot. Condition steps get a handle per branch so a
+     * dragged connection carries the branch it started from; everything else has
+     * a single unnamed slot. Empty for EXIT, which ends the path.
+     */
+    sourceHandles?: {id: string; color: string; connectable: boolean}[];
   };
 }) {
   const Icon = data.icon;
@@ -253,12 +301,15 @@ function CustomNode({
   const bgColor = data.bgColor;
   const [showActions, setShowActions] = useState(false);
 
+  const sourceHandles = data.sourceHandles ?? [];
+
   return (
     <>
       <Handle
+        id={TARGET_HANDLE_ID}
         type="target"
         position={Position.Top}
-        style={{opacity: 0, cursor: 'default', pointerEvents: 'none'}}
+        style={HANDLE_STYLE}
       />
 
       <div
@@ -420,11 +471,23 @@ function CustomNode({
         )}
       </div>
 
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        style={{opacity: 0, cursor: 'default', pointerEvents: 'none'}}
-      />
+      {sourceHandles.map((handle, index) => (
+        <Handle
+          key={handle.id}
+          id={handle.id}
+          type="source"
+          position={Position.Bottom}
+          isConnectable={handle.connectable}
+          title={handle.connectable ? 'Drag to connect to another step' : undefined}
+          style={{
+            ...HANDLE_STYLE,
+            background: handle.color,
+            // Spread multiple branch handles evenly across the bottom edge
+            left: `${((index + 1) / (sourceHandles.length + 1)) * 100}%`,
+            cursor: handle.connectable ? 'crosshair' : 'default',
+          }}
+        />
+      ))}
     </>
   );
 }
@@ -433,6 +496,17 @@ const nodeTypes = {
   custom: CustomNode,
   addStep: AddStepNode,
 };
+
+const edgeTypes = {
+  workflow: WorkflowEdge,
+};
+
+/**
+ * Where a newly picked step should land.
+ * - `append`: after an existing step (optionally on a specific condition branch)
+ * - `insert`: in the middle of an existing transition, splitting it in two
+ */
+type PickerContext = {mode: 'append'; fromStepId: string; branch?: string} | {mode: 'insert'; transitionId: string};
 
 // Step type options for adding new steps
 const STEP_TYPE_OPTIONS = [
@@ -446,10 +520,8 @@ const STEP_TYPE_OPTIONS = [
 ];
 
 export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderProps) {
-  const [addStepContext, setAddStepContext] = useState<{
-    fromStepId: string | null;
-    branch?: string;
-  } | null>(null);
+  const [pickerContext, setPickerContext] = useState<PickerContext | null>(null);
+  const [transitionToDisconnect, setTransitionToDisconnect] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [stepToDelete, setStepToDelete] = useState<string | null>(null);
   const [deleteMode, setDeleteMode] = useState<'splice' | 'cascade'>('splice');
@@ -505,6 +577,20 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
       const color = STEP_TYPE_COLORS[step.type as keyof typeof STEP_TYPE_COLORS] || '#6b7280';
       const bgColor = STEP_TYPE_BG[step.type as keyof typeof STEP_TYPE_BG] || '#f3f4f6';
 
+      // EXIT ends the path, a condition routes per branch, everything else has a
+      // single next step.
+      const outgoing = step.outgoingTransitions ?? [];
+      const sourceHandles =
+        step.type === 'EXIT'
+          ? []
+          : step.type === 'CONDITION'
+            ? getBranchHandles(step.config, outgoing).map(branchId => ({
+                id: branchId,
+                color: getBranchColor(step.config, branchId),
+                connectable: !outgoing.some(t => getTransitionBranch(t.condition) === branchId),
+              }))
+            : [{id: SOURCE_HANDLE_ID, color: '#94a3b8', connectable: outgoing.length === 0}];
+
       return {
         id: step.id,
         type: 'custom',
@@ -515,6 +601,7 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
           icon: Icon,
           color,
           bgColor,
+          sourceHandles,
           template: step.template,
           config: step.config,
           onEdit: () => handleEditStep(step.id),
@@ -544,7 +631,7 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
               draggable: false,
               data: {
                 label: getBranchLabel(step.config, branchId),
-                onClick: () => setAddStepContext({fromStepId: step.id, branch: branchId}),
+                onClick: () => setPickerContext({mode: 'append', fromStepId: step.id, branch: branchId}),
               },
             });
           }
@@ -559,7 +646,7 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
             draggable: false,
             data: {
               label: '',
-              onClick: () => setAddStepContext({fromStepId: step.id}),
+              onClick: () => setPickerContext({mode: 'append', fromStepId: step.id}),
             },
           });
         }
@@ -590,20 +677,16 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
             id: transition.id,
             source: step.id,
             target: transition.toStepId,
-            type: 'smoothstep',
+            sourceHandle: branch ?? SOURCE_HANDLE_ID,
+            targetHandle: TARGET_HANDLE_ID,
+            type: 'workflow',
             animated: false,
-            label: isConditional ? branchLabel : undefined,
-            labelStyle: {
-              fill: isConditional ? branchColor : '#64748b',
-              fontWeight: 600,
-              fontSize: 12,
+            data: {
+              branchLabel: isConditional ? branchLabel : undefined,
+              branchColor: isConditional ? branchColor : '#64748b',
+              onInsert: () => setPickerContext({mode: 'insert', transitionId: transition.id}),
+              onDisconnect: () => setTransitionToDisconnect(transition.id),
             },
-            labelBgStyle: {
-              fill: '#fff',
-              fillOpacity: 0.95,
-            },
-            labelBgPadding: [8, 4] as [number, number],
-            labelBgBorderRadius: 4,
             style: {
               stroke: '#94a3b8',
               strokeWidth: 2,
@@ -641,6 +724,8 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
               id: `${step.id}-add-${branchId}-edge`,
               source: step.id,
               target: `${step.id}-add-${branchId}`,
+              sourceHandle: branchId,
+              targetHandle: TARGET_HANDLE_ID,
               type: 'smoothstep',
               animated: false,
               label,
@@ -659,6 +744,8 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
             id: `${step.id}-add-edge`,
             source: step.id,
             target: `${step.id}-add`,
+            sourceHandle: SOURCE_HANDLE_ID,
+            targetHandle: TARGET_HANDLE_ID,
             type: 'smoothstep',
             animated: false,
             style: {stroke: '#94a3b8', strokeWidth: 2, strokeDasharray: '5,5'},
@@ -694,7 +781,39 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
 
   const handleCreateStep = useCallback(
     async (stepType: string) => {
-      if (!addStepContext?.fromStepId) return;
+      if (!pickerContext) return;
+
+      // Inserting into an existing transition is a single atomic call — the API
+      // re-points the transition at the new step and wires it on to the original
+      // target, so the graph is never left half-connected.
+      if (pickerContext.mode === 'insert') {
+        try {
+          const newStep = await network.fetch<WorkflowStep, typeof WorkflowSchemas.insertStep>(
+            'POST',
+            `/workflows/${workflowId}/transitions/${pickerContext.transitionId}/insert-step`,
+            {
+              type: stepType as WorkflowStep['type'],
+              name: `New ${stepType.toLowerCase().replace('_', ' ')}`,
+              position: {x: 0, y: 0}, // Will be auto-positioned by dagre layout
+              config: {},
+            },
+          );
+
+          toast.success('Step inserted');
+          setPickerContext(null);
+          onUpdate();
+
+          setTimeout(() => {
+            const event = new CustomEvent('workflow-edit-step', {detail: {stepId: newStep.id}});
+            window.dispatchEvent(event);
+          }, 100);
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : 'Failed to insert step');
+        }
+        return;
+      }
+
+      const addStepContext = pickerContext;
 
       try {
         // Validate that this branch doesn't already have a transition
@@ -754,7 +873,7 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
         );
 
         toast.success('Step added successfully');
-        setAddStepContext(null);
+        setPickerContext(null);
         onUpdate();
 
         // Trigger edit dialog for the new step after a short delay
@@ -767,7 +886,7 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [addStepContext, workflowId, onUpdate],
+    [pickerContext, workflowId, onUpdate],
   );
 
   // Get all steps that will be affected by deleting a step (the step itself + all downstream steps)
@@ -828,6 +947,143 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
     }
   };
 
+  /** Look up a transition (and the steps on either end of it) by transition id. */
+  const findTransition = useCallback(
+    (transitionId: string) => {
+      for (const step of steps) {
+        const transition = step.outgoingTransitions?.find(t => t.id === transitionId);
+        if (transition) {
+          return {transition, fromStep: step, toStep: steps.find(s => s.id === transition.toStepId)};
+        }
+      }
+      return null;
+    },
+    [steps],
+  );
+
+  const handleDisconnect = async () => {
+    if (!transitionToDisconnect) return;
+
+    try {
+      await network.fetch('DELETE', `/workflows/${workflowId}/transitions/${transitionToDisconnect}`);
+      toast.success('Steps disconnected');
+      onUpdate();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to disconnect steps');
+    } finally {
+      setTransitionToDisconnect(null);
+    }
+  };
+
+  /**
+   * Steps that can be wired up from `fromStepId`.
+   *
+   * Only steps that are currently unreachable (no incoming transition) qualify —
+   * these are the ones left dangling by a disconnect, and offering them here is
+   * what makes disconnecting reversible without rebuilding the branch. Anything
+   * downstream of the source is excluded so we can't create a cycle.
+   */
+  const getReconnectCandidates = useCallback(
+    (fromStepId: string) => {
+      const downstream = new Set(getAffectedSteps(fromStepId).map(s => s.id));
+      return steps.filter(
+        s => s.type !== 'TRIGGER' && !downstream.has(s.id) && (s.incomingTransitions?.length ?? 0) === 0,
+      );
+    },
+    [steps, getAffectedSteps],
+  );
+
+  /**
+   * Gates connections while they are being dragged, so an invalid drop is refused
+   * by React Flow rather than bouncing off the API. Mirrors the server-side rules
+   * in `WorkflowService.createTransition`.
+   */
+  const isValidConnection = useCallback(
+    (connection: Connection | Edge) => {
+      const {source, target, sourceHandle} = connection;
+      if (!source || !target || source === target) return false;
+
+      const fromStep = steps.find(s => s.id === source);
+      const toStep = steps.find(s => s.id === target);
+
+      // Either end being unknown means it's one of the "+" placeholder nodes
+      if (!fromStep || !toStep) return false;
+      if (fromStep.type === 'EXIT') return false;
+
+      // The slot being dragged from has to be free
+      if (fromStep.type === 'CONDITION') {
+        if (fromStep.outgoingTransitions?.some(t => getTransitionBranch(t.condition) === sourceHandle)) return false;
+      } else if ((fromStep.outgoingTransitions?.length ?? 0) > 0) {
+        return false;
+      }
+
+      // Connecting to something upstream would close a loop
+      return !getAffectedSteps(target).some(s => s.id === source);
+    },
+    [steps, getAffectedSteps],
+  );
+
+  const handleConnect = useCallback(
+    async (connection: Connection) => {
+      const {source, target, sourceHandle} = connection;
+      if (!source || !target || !isValidConnection(connection)) return;
+
+      const fromStep = steps.find(s => s.id === source);
+      const branch = fromStep?.type === 'CONDITION' ? sourceHandle : null;
+      const expectedBranches = fromStep?.type === 'CONDITION' ? getExpectedBranches(fromStep.config) : [];
+      const branchIndex = branch ? expectedBranches.indexOf(branch) : -1;
+
+      try {
+        await network.fetch<unknown, typeof WorkflowSchemas.createTransition>(
+          'POST',
+          `/workflows/${workflowId}/transitions`,
+          {
+            fromStepId: source,
+            toStepId: target,
+            condition: branch ? {branch} : null,
+            priority: branchIndex >= 0 ? branchIndex : 0,
+          },
+        );
+
+        toast.success('Steps connected');
+        onUpdate();
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to connect steps');
+      }
+    },
+    [isValidConnection, steps, workflowId, onUpdate],
+  );
+
+  const handleConnectToExisting = useCallback(
+    async (toStepId: string) => {
+      if (pickerContext?.mode !== 'append') return;
+
+      try {
+        const fromStep = steps.find(s => s.id === pickerContext.fromStepId);
+        const expectedBranches = fromStep?.type === 'CONDITION' ? getExpectedBranches(fromStep.config) : [];
+        const branchIndex = pickerContext.branch ? expectedBranches.indexOf(pickerContext.branch) : -1;
+
+        await network.fetch<unknown, typeof WorkflowSchemas.createTransition>(
+          'POST',
+          `/workflows/${workflowId}/transitions`,
+          {
+            fromStepId: pickerContext.fromStepId,
+            toStepId,
+            condition: pickerContext.branch ? {branch: pickerContext.branch} : null,
+            priority: branchIndex >= 0 ? branchIndex : 0,
+          },
+        );
+
+        toast.success('Steps connected');
+        setPickerContext(null);
+        onUpdate();
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to connect steps');
+      }
+    },
+    [pickerContext, steps, workflowId, onUpdate],
+  );
+
 
   if (steps.length === 0) {
     return (
@@ -860,6 +1116,7 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
           fitView
           fitViewOptions={{
             padding: 0.3,
@@ -869,7 +1126,10 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
           minZoom={0.1}
           maxZoom={2}
           nodesDraggable={false}
-          nodesConnectable={false}
+          nodesConnectable={true}
+          onConnect={handleConnect}
+          isValidConnection={isValidConnection}
+          connectionLineType={ConnectionLineType.SmoothStep}
           elementsSelectable={true}
           defaultEdgeOptions={{
             type: 'smoothstep',
@@ -918,55 +1178,136 @@ export function WorkflowBuilder({workflowId, steps, onUpdate}: WorkflowBuilderPr
               )}
             </button>
           </Panel>
-{rawEdges.length === 0 && steps.length > 1 && (
-            <Panel
-              position="bottom-center"
-              className="bg-white border border-neutral-200 px-4 py-2.5 rounded-lg shadow-sm"
-            >
-              <div className="flex items-center gap-2 text-sm text-neutral-600">
-                <Lightbulb className="h-4 w-4" />
-                <span>Click the + buttons to add and connect steps.</span>
-              </div>
-            </Panel>
-          )}
+          <Panel
+            position="bottom-center"
+            className="bg-white border border-neutral-200 px-4 py-2.5 rounded-lg shadow-sm"
+          >
+            <div className="flex items-center gap-2 text-sm text-neutral-600">
+              <Lightbulb className="h-4 w-4" />
+              <span>
+                Click a + to add a step, hover a connection to insert or disconnect, or drag between the dots to
+                connect two steps.
+              </span>
+            </div>
+          </Panel>
         </ReactFlow>
       </div>
 
-      {/* Step type picker dialog */}
-      <Dialog open={!!addStepContext} onOpenChange={open => !open && setAddStepContext(null)}>
+      {/* Step type picker dialog — used both to append after a step and to insert into a transition */}
+      <Dialog open={!!pickerContext} onOpenChange={open => !open && setPickerContext(null)}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Add Step</DialogTitle>
+            <DialogTitle>{pickerContext?.mode === 'insert' ? 'Insert Step' : 'Add Step'}</DialogTitle>
           </DialogHeader>
+          {pickerContext?.mode === 'insert' && (
+            <p className="text-sm text-neutral-600">
+              The new step is placed between these two steps. The connection below it is kept.
+            </p>
+          )}
           <div className="grid grid-cols-2 gap-3 py-4">
-            {STEP_TYPE_OPTIONS.map(option => {
-              const Icon = option.icon;
-              return (
-                <button
-                  key={option.value}
-                  onClick={() => handleCreateStep(option.value)}
-                  className="flex flex-col items-center gap-2 p-4 rounded-lg border border-neutral-200 hover:border-neutral-400 hover:bg-neutral-50 transition-all group"
-                >
-                  <div
-                    className="w-12 h-12 rounded-lg flex items-center justify-center transition-transform group-hover:scale-110"
-                    style={{
-                      backgroundColor: `${option.color}15`,
-                    }}
+            {STEP_TYPE_OPTIONS
+              // An exit step ends the path, so it can never sit between two steps.
+              .filter(option => !(pickerContext?.mode === 'insert' && option.value === 'EXIT'))
+              .map(option => {
+                const Icon = option.icon;
+                return (
+                  <button
+                    key={option.value}
+                    onClick={() => handleCreateStep(option.value)}
+                    className="flex flex-col items-center gap-2 p-4 rounded-lg border border-neutral-200 hover:border-neutral-400 hover:bg-neutral-50 transition-all group"
                   >
-                    <Icon className="h-6 w-6" style={{color: option.color}} />
-                  </div>
-                  <span className="text-sm font-medium text-neutral-900">{option.label}</span>
-                </button>
-              );
-            })}
+                    <div
+                      className="w-12 h-12 rounded-lg flex items-center justify-center transition-transform group-hover:scale-110"
+                      style={{
+                        backgroundColor: `${option.color}15`,
+                      }}
+                    >
+                      <Icon className="h-6 w-6" style={{color: option.color}} />
+                    </div>
+                    <span className="text-sm font-medium text-neutral-900">{option.label}</span>
+                  </button>
+                );
+              })}
           </div>
+
+          {/* Reattaching a disconnected step, so a disconnect isn't a one-way door */}
+          {pickerContext?.mode === 'append' &&
+            (() => {
+              const candidates = getReconnectCandidates(pickerContext.fromStepId);
+              if (candidates.length === 0) return null;
+
+              return (
+                <div className="border-t border-neutral-200 pt-4">
+                  <p className="text-xs font-medium text-neutral-500 mb-2">Or connect to a disconnected step</p>
+                  <div className="space-y-1.5 max-h-40 overflow-y-auto">
+                    {candidates.map(candidate => {
+                      const Icon = STEP_TYPE_ICONS[candidate.type as keyof typeof STEP_TYPE_ICONS] ?? GitBranch;
+                      const color = STEP_TYPE_COLORS[candidate.type as keyof typeof STEP_TYPE_COLORS] ?? '#6b7280';
+                      return (
+                        <button
+                          key={candidate.id}
+                          onClick={() => handleConnectToExisting(candidate.id)}
+                          className="w-full flex items-center gap-2.5 p-2.5 rounded-lg border border-neutral-200 hover:border-neutral-400 hover:bg-neutral-50 transition-all text-left"
+                        >
+                          <Icon className="h-4 w-4 shrink-0" style={{color}} />
+                          <span className="text-sm text-neutral-900 truncate flex-1">{candidate.name}</span>
+                          <span className="text-xs text-neutral-500 shrink-0">
+                            {STEP_TYPE_LABELS[candidate.type] ?? candidate.type}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })()}
+
           <DialogFooter>
-            <Button variant="outline" onClick={() => setAddStepContext(null)}>
+            <Button variant="outline" onClick={() => setPickerContext(null)}>
               Cancel
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Disconnect confirmation */}
+      {transitionToDisconnect &&
+        (() => {
+          const found = findTransition(transitionToDisconnect);
+          if (!found) return null;
+
+          // Everything below the target loses its path from the trigger. It stays
+          // on the canvas and can be reattached from any + button.
+          const orphaned = found.toStep ? getAffectedSteps(found.toStep.id) : [];
+
+          return (
+            <Dialog open onOpenChange={open => !open && setTransitionToDisconnect(null)}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Disconnect steps</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-3 py-1">
+                  <p className="text-sm text-neutral-600">
+                    Remove the connection from &quot;{found.fromStep.name}&quot; to &quot;{found.toStep?.name}&quot;?
+                  </p>
+                  {orphaned.length > 0 && (
+                    <p className="text-sm text-neutral-600">
+                      {orphaned.length === 1 ? 'This step' : `These ${orphaned.length} steps`} will no longer be
+                      reachable. Nothing is deleted — reconnect{orphaned.length === 1 ? ' it' : ' them'} from any{' '}
+                      <span className="font-medium">+</span> button.
+                    </p>
+                  )}
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setTransitionToDisconnect(null)}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleDisconnect}>Disconnect</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          );
+        })()}
 
       {stepToDelete &&
         (() => {

--- a/apps/web/src/components/WorkflowEdge.tsx
+++ b/apps/web/src/components/WorkflowEdge.tsx
@@ -1,0 +1,105 @@
+import {BaseEdge, EdgeLabelRenderer, type EdgeProps, getSmoothStepPath} from '@xyflow/react';
+import {Plus, Unlink} from 'lucide-react';
+import {useState} from 'react';
+
+export interface WorkflowEdgeData extends Record<string, unknown> {
+  /** Branch label ("Yes", "No", a named branch…). Undefined for plain transitions. */
+  branchLabel?: string;
+  /** Colour used for the branch label. */
+  branchColor?: string;
+  onInsert: () => void;
+  onDisconnect: () => void;
+}
+
+/**
+ * Transition edge with an inline toolbar.
+ *
+ * Hovering the edge (or the label itself) swaps the branch label for two
+ * actions: insert a step in the middle of the transition, or disconnect the two
+ * steps. The label and the toolbar occupy the same spot so the graph stays
+ * uncluttered when nothing is hovered.
+ */
+export function WorkflowEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}: EdgeProps) {
+  const [hovered, setHovered] = useState(false);
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const {branchLabel, branchColor, onInsert, onDisconnect} = (data ?? {}) as WorkflowEdgeData;
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={style} markerEnd={markerEnd} />
+
+      {/* Invisible fat path so the edge is comfortable to hover, not just the 2px stroke */}
+      <path
+        d={edgePath}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={24}
+        style={{pointerEvents: 'stroke'}}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      />
+
+      <EdgeLabelRenderer>
+        <div
+          className="nodrag nopan absolute"
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: 'all',
+          }}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          {hovered ? (
+            <div className="flex items-center gap-0.5 rounded-lg border border-neutral-200 bg-white p-0.5 shadow-md">
+              <button
+                type="button"
+                onClick={onInsert}
+                title="Insert a step here"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={onDisconnect}
+                title="Disconnect these steps"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-neutral-600 transition-colors hover:bg-red-50 hover:text-red-600"
+              >
+                <Unlink className="h-4 w-4" />
+              </button>
+            </div>
+          ) : (
+            branchLabel && (
+              <span
+                className="rounded bg-white/95 px-2 py-1 text-xs font-semibold"
+                style={{color: branchColor}}
+              >
+                {branchLabel}
+              </span>
+            )
+          )}
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -248,6 +248,17 @@ export const WorkflowSchemas = {
     config: jsonSchema.optional(),
     templateId: uuid.optional().nullable(),
   }),
+  // Payload for POST /workflows/:id/transitions/:transitionId/insert-step.
+  // Mirrors `addStep` minus `autoConnect` (the transition being split already
+  // determines both sides of the wiring) and with an optional position, since
+  // the builder lays the graph out with dagre anyway.
+  insertStep: z.object({
+    type: z.nativeEnum(WorkflowStepType),
+    name: z.string().min(1).max(100),
+    position: jsonSchema.optional(),
+    config: jsonSchema,
+    templateId: uuid.optional(),
+  }),
   createTransition: z.object({
     fromStepId: uuid,
     toStepId: uuid,


### PR DESCRIPTION
> Oops... I forgot to add a delay at the beginning of my 32 steps workflow, FML 🤯🔫

👆 this is why I'm opening this PR today

## Description

Adding a step to a workflow was only possible at the end of a path, making it frankly unusable when you have to edit a big workflow as you would have to recreate all the steps one by one if you desire to just insert a new one. The `+` placeholder appeared solely on steps with no outgoing transition, and the canvas was otherwise inert: no way to insert a step between two existing ones, and no way to disconnect two steps. Getting a step into the middle of a flow meant deleting everything below it and rebuilding the branch by hand.

<img width="954" height="944" alt="CleanShot 2026-08-04 at 00 27 10@2x" src="https://github.com/user-attachments/assets/6b6b993f-a2cf-468e-9c14-c27169d2c3aa" />

This adds three things to the editor:

**Insert between steps.** Transitions render as a custom edge with an inline toolbar. Hovering a connection swaps its branch label for two actions, insert a step here, or disconnect. Insert is a single atomic API call: `POST /workflows/:id/transitions/:transitionId/insert-step` re-points the existing transition at the new step (keeping its condition, so a condition branch keeps its label) and creates a fresh transition on to the original target. Doing it client-side would have meant three non-atomic calls that can leave the graph half-connected.

<img width="800" height="548" alt="CleanShot 2026-08-04 at 00 30 02" src="https://github.com/user-attachments/assets/848aa7a9-8efc-4b63-b648-d80c01be246a" />

A `CONDITION` inserted this way attaches the downstream step to its first branch rather than leaving the new transition unconditional, a condition routes exclusively by branch, so an unconditional outgoing transition would never be taken and the downstream step would be stranded.

<img width="800" height="544" alt="CleanShot 2026-08-04 at 00 31 15" src="https://github.com/user-attachments/assets/012d2ab7-93e4-4716-9035-7f38a882220a" />

**Disconnect.** Wired to the existing `DELETE /workflows/:id/transitions/:transitionId` endpoint, which had no caller in the dashboard until now. The confirmation names how many steps become unreachable and makes clear nothing is deleted.

<img width="800" height="547" alt="CleanShot 2026-08-04 at 00 33 10" src="https://github.com/user-attachments/assets/9e057d5e-ef3c-47b2-904d-1048b1997a7d" />

**Draw connections by hand.** Handles are visible and connectable. Condition steps expose one handle per branch, spread along the bottom edge and coloured to match, so a dragged connection carries the branch it started from. Handles on occupied slots are non-connectable, and `isValidConnection` mirrors the server rules so an invalid drop is refused mid-drag rather than bouncing off the API.

<img width="800" height="547" alt="CleanShot 2026-08-04 at 00 34 05" src="https://github.com/user-attachments/assets/d67dded6-1fc8-45aa-a886-50861f210370" />

The step picker also gained a "connect to a disconnected step" section. Without it, disconnecting would be a one-way door, the `+` button only ever creates *new* steps, so a detached subtree could never be reattached.

<img width="800" height="547" alt="CleanShot 2026-08-04 at 00 35 15" src="https://github.com/user-attachments/assets/7bff5dfa-42d2-443d-9777-ced29f51c70c" />

## ⚠️ Behaviour change to `createTransition` 

Worth a maintainer opinion @driaug.

`POST /workflows/:id/transitions` previously accepted almost anything. Now that connections can be drawn by hand, it enforces the invariants the UI has only ever assumed:

| Rule | Rationale |
|---|---|
| No self-connection | Previously surfaced as a misleading `404 One or both steps not found` |
| No outgoing transition from `EXIT` | An exit terminates its path |
| At most one outgoing transition from a non-condition step | A second makes the next hop ambiguous at execution time; branching is what `CONDITION` is for |
| No cycles | `WorkflowExecutionService` puts no bound on how many times an execution may traverse the graph, so a loop would run indefinitely |

**This is a behaviour change on a public endpoint.** Anyone driving it programmatically to build a fan-out or a loop now gets a `400` where they previously got a `201`. Existing stored transitions are untouched, validation applies only to newly created ones.

I think all four are correct, but the cycle check is the most opinionated and the easiest to drop if you'd rather ship the rest first. Happy to split it out.

## Type of Change

- [x] `feat:` New feature (MINOR version bump)

## Testing

- 10 new integration tests in `WorkflowService.test.ts` covering the insert endpoint (transition split, branch/priority preservation, condition-attaches-to-first-branch, `EXIT`/`TRIGGER` rejection, cross-project 404) and each new validation rule.
- `WorkflowService.test.ts`: 66 passed.
- Workflow controller + execution suites: 86 passed. The new validation doesn't disturb existing fixtures, which build multi-transition graphs via raw Prisma.
- `yarn lint` clean, 0 errors, no new warnings.
- `tsc --noEmit` clean on `apps/web` and `apps/api`.

Manually exercised in the dashboard:
- Inserting a step in between two existing steps
- Disconnecting two connected steps
- Re-connected two disconnected steps by dragging the output connector of a step towards the input connector of a different step

Note: first time contributor, and I'm a customer of the cloud version so I don't really have things setup to test what happens after creating the workflow at this time. Hoping on a bit of guidance, if this contribution sounds acceptable, on how to test fully and what to be sure I test before this can land, thanks.

## Checklist

- [x] PR title follows conventional commits format
- [x] Code builds successfully
- [x] Tests pass locally
- [ ] Documentation updated (if needed)

## Related Issues

Found this in discord where somebody asked for something similar: https://discord.com/channels/990573272561242162/1511239784905838743