### PR TITLE
feat(i18n): add Swedish (sv) translations

### DIFF
--- a/packages/shared/src/i18n/index.ts
+++ b/packages/shared/src/i18n/index.ts
@@ -15,6 +15,7 @@ import zhTWTranslations from './locales/zh-TW.json' with {type: 'json'};
 import zhHKTranslations from './locales/zh-HK.json' with {type: 'json'};
 import zhCNTranslations from './locales/zh-CN.json' with {type: 'json'};
 import jaTranslations from './locales/ja.json' with {type: 'json'};
+import svTranslations from './locales/sv.json' with {type: 'json'};
 
 export {
   SUPPORTED_LANGUAGES,
@@ -40,21 +41,22 @@ export interface Translations {
 
 // Static mapping of language codes to translations
 const translationsMap: Record<string, Translations> = {
-  en: enTranslations,
-  nl: nlTranslations,
-  de: deTranslations,
-  fr: frTranslations,
-  hi: hiTranslations,
-  pt: ptTranslations,
-  bg: bgTranslations,
-  cs: csTranslations,
-  pl: plTranslations,
-  es: esTranslations,
-  it: itTranslations,
+  'en': enTranslations,
+  'nl': nlTranslations,
+  'de': deTranslations,
+  'fr': frTranslations,
+  'hi': hiTranslations,
+  'pt': ptTranslations,
+  'bg': bgTranslations,
+  'cs': csTranslations,
+  'pl': plTranslations,
+  'es': esTranslations,
+  'it': itTranslations,
   'zh-TW': zhTWTranslations,
   'zh-HK': zhHKTranslations,
   'zh-CN': zhCNTranslations,
-  ja: jaTranslations,
+  'ja': jaTranslations,
+  'sv': svTranslations,
 };
 
 // In-memory cache for loaded translations

--- a/packages/shared/src/i18n/languages.ts
+++ b/packages/shared/src/i18n/languages.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_LANGUAGES: Language[] = [
   {code: 'zh-HK', name: 'Chinese (Traditional, Hong Kong)', nativeName: '繁體中文（香港）', flag: '🇭🇰'},
   {code: 'zh-CN', name: 'Chinese (Simplified, China)', nativeName: '简体中文', flag: '🇨🇳'},
   {code: 'ja', name: 'Japanese', nativeName: '日本語', flag: '🇯🇵'},
+  {code: 'sv', name: 'Swedish', nativeName: 'Svenska', flag: '🇸🇪'},
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/packages/shared/src/i18n/locales/sv.json
+++ b/packages/shared/src/i18n/locales/sv.json
@@ -1,0 +1,45 @@
+{
+  "pages": {
+    "unsubscribe": {
+      "title": "Avsluta prenumeration",
+      "description": "Tråkigt att du lämnar oss. Är du säker på att du vill avsluta prenumerationen för {email}?",
+      "button": "Avsluta prenumerationen",
+      "buttonLoading": "Avslutar prenumerationen...",
+      "managePreferences": "Hantera inställningar istället",
+      "successTitle": "Din prenumeration är avslutad",
+      "successDescription": "{email} har avslutat sin prenumeration. Du kommer inte längre att få e-post från oss.",
+      "changedMind": "Ångrat dig?",
+      "subscribeAgain": "Prenumerera igen"
+    },
+    "subscribe": {
+      "title": "Prenumerera på uppdateringar",
+      "description": "Vill du prenumerera med {email} för att få e-post?",
+      "button": "Prenumerera",
+      "buttonLoading": "Prenumererar...",
+      "successTitle": "Du prenumererar nu!",
+      "successDescription": "{email} prenumererar nu på e-post från oss."
+    },
+    "manage": {
+      "title": "Hantera inställningar",
+      "description": "Hantera e-postinställningar för {email}",
+      "subscriptionLabel": "E-postprenumeration",
+      "subscribedStatus": "Du prenumererar för närvarande på e-post",
+      "unsubscribedStatus": "Du prenumererar för närvarande inte på e-post",
+      "subscribedSuccess": "Prenumeration lyckades!",
+      "unsubscribedSuccess": "Prenumerationen avslutades!",
+      "unsubscribeCompletely": "Avsluta prenumerationen helt",
+      "subscribeToEmails": "Prenumerera på e-post",
+      "disclaimer": "På den här sidan kan du hantera dina e-postinställningar. Din prenumerationsstatus uppdateras i realtid."
+    },
+    "common": {
+      "loading": "Laddar...",
+      "error": "Fel"
+    }
+  },
+  "email": {
+    "footer": {
+      "unsubscribeText": "Du fick det här e-postmeddelandet eftersom du anmält dig till att ta emot e-post från {projectName}. Om du inte längre vill ha den här typen av e-post kan du",
+      "updatePreferences": "uppdatera dina inställningar"
+    }
+  }
+}


### PR DESCRIPTION
Adds Swedish translations for the contact-facing pages and email footer.

Part of #246