### PR TITLE
fix(smtp): preserve Reply-To when relaying to /v1/send

### DIFF
--- a/apps/smtp/src/server.ts
+++ b/apps/smtp/src/server.ts
@@ -291,6 +291,12 @@ function handleData(
     // Build from object with name if available
     const from = fromName ? {name: fromName, email: fromAddress} : fromAddress;
 
+    // Reply-To is in `standardHeaders` below, so it is deliberately excluded from
+    // `customHeaders`. Carry it in the API's own `reply` field instead — without
+    // this the header is parsed and then silently dropped, and the recipient's
+    // reply goes to the From address.
+    const replyTo = parsed.replyTo?.value[0]?.address;
+
     // Parse recipients with names from To/CC headers
     // Build a map of email -> name from the parsed headers
     const recipientNameMap = new Map<string, string>();
@@ -402,6 +408,7 @@ function handleData(
           to: recipients,
           subject: parsed.subject,
           body: bodyContent,
+          reply: replyTo,
           headers: Object.keys(customHeaders).length > 0 ? customHeaders : undefined,
           attachments: attachments,
         }),


### PR DESCRIPTION
## Problem

The SMTP relay parses each incoming message and re-sends it through `POST /v1/send`. `reply-to` is listed in `standardHeaders`, so it is correctly excluded from `customHeaders` — but nothing puts it back. The request body has no `reply` field:

```ts
body: JSON.stringify({
  from: from,
  to: recipients,
  subject: parsed.subject,
  body: bodyContent,
  headers: ...,
  attachments: attachments,
})
```

The header is parsed and then silently dropped. Anyone relaying transactional mail through the SMTP server loses `Reply-To`, and replies go to the `From` address instead.

Everything downstream already supports it, so this is only a gap in the relay:

- `packages/shared` — the send schema has `reply: z.ZodOptional<z.ZodString>`
- `apps/api/src/controllers/v1/Actions.ts` — destructures `reply` and passes it as `replyTo`
- `apps/api/src/services/EmailService.ts` — forwards `reply: email.replyTo`
- `apps/api/src/services/SESService.ts` — writes `Reply-To: ${reply || from.email}` into the raw MIME

## Evidence

On a self-hosted install relaying ~57k transactional emails a month through the SMTP server, not one has ever carried a `Reply-To`:

```
sourceType     |   total | with_replyto
TRANSACTIONAL  |  57,769 |            0     ← via the SMTP relay
CAMPAIGN       | 317,038 |      317,038     ← via the API directly
```

Campaigns, which call the API directly, set it every time. Only the relay path loses it.

## Fix

Read `parsed.replyTo` the same way the surrounding code already reads `parsed.from`, and pass it through:

```ts
const replyTo = parsed.replyTo?.value[0]?.address;
...
  reply: replyTo,
```

`reply` is optional in the schema, so messages without a `Reply-To` header are unaffected — `undefined` is simply omitted from the JSON body.

## Notes

- Only the first address is taken. `Reply-To` permits a list, but the API's `reply` field is a single string, so a list would need a schema change. Taking the first address matches how `from` is handled a few lines above.
- No behaviour change for any message that does not set `Reply-To`.
