### PR TITLE
fix: re-check subscription before SES submission

### DIFF
--- a/apps/api/src/jobs/__tests__/email-processor.test.ts
+++ b/apps/api/src/jobs/__tests__/email-processor.test.ts
@@ -2,6 +2,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {EmailSourceType, EmailStatus, TrackingMode} from '@plunk/db';
 import {toPrismaJson} from '@plunk/types';
 import {createServiceMocks, factories, getPrismaClient} from '../../../../../test/helpers';
+import {submitEmailWithSubscriptionCheck} from '../email-processor';
 
 // Mock MeterService
 vi.mock('../../services/MeterService.js', () => ({
@@ -123,6 +124,100 @@ describe('Email Processor', () => {
       });
 
       expect(template.type).toBe('TRANSACTIONAL');
+    });
+
+    it('should suppress queued marketing email when the contact unsubscribes before SES submission', async () => {
+      const contact = await factories.createContact({projectId});
+      const campaign = await factories.createCampaign({projectId});
+      const email = await factories.createEmail(projectId, contact.id, {
+        campaignId: campaign.id,
+        status: EmailStatus.SENDING,
+      });
+      const submit = vi.fn().mockResolvedValue({messageId: 'ses-message-id'});
+
+      // The email was queued while subscribed, then waited behind a backlog.
+      await prisma.contact.update({where: {id: contact.id}, data: {subscribed: false}});
+
+      const result = await submitEmailWithSubscriptionCheck(
+        {emailId: email.id, sourceType: EmailSourceType.CAMPAIGN, hasRecipientOverride: false},
+        submit,
+      );
+
+      expect(result).toEqual({submitted: false});
+      expect(submit).not.toHaveBeenCalled();
+      await expect(prisma.email.findUnique({where: {id: email.id}})).resolves.toMatchObject({
+        status: EmailStatus.FAILED,
+        error: 'Contact is unsubscribed from marketing emails',
+      });
+    });
+
+    it('should submit queued transactional email after the contact unsubscribes', async () => {
+      const contact = await factories.createContact({projectId, subscribed: false});
+      const email = await factories.createEmail(projectId, contact.id, {
+        sourceType: EmailSourceType.TRANSACTIONAL,
+        status: EmailStatus.SENDING,
+      });
+      const sesResult = {messageId: 'ses-message-id'};
+      const submit = vi.fn().mockResolvedValue(sesResult);
+
+      const result = await submitEmailWithSubscriptionCheck(
+        {emailId: email.id, sourceType: EmailSourceType.TRANSACTIONAL, hasRecipientOverride: false},
+        submit,
+      );
+
+      expect(result).toEqual({submitted: true, result: sesResult});
+      expect(submit).toHaveBeenCalledOnce();
+    });
+
+    it('should submit queued transactional email with a headless template after unsubscribe', async () => {
+      const contact = await factories.createContact({projectId, subscribed: false});
+      const template = await factories.createTemplate({projectId, type: 'HEADLESS'});
+      const email = await factories.createEmail(projectId, contact.id, {
+        templateId: template.id,
+        sourceType: EmailSourceType.TRANSACTIONAL,
+        status: EmailStatus.SENDING,
+      });
+      const sesResult = {messageId: 'ses-message-id'};
+      const submit = vi.fn().mockResolvedValue(sesResult);
+
+      const result = await submitEmailWithSubscriptionCheck(
+        {
+          emailId: email.id,
+          sourceType: EmailSourceType.TRANSACTIONAL,
+          templateType: 'HEADLESS',
+          hasRecipientOverride: false,
+        },
+        submit,
+      );
+
+      expect(result).toEqual({submitted: true, result: sesResult});
+      expect(submit).toHaveBeenCalledOnce();
+    });
+
+    it('should suppress a queued marketing template sent through the transactional API', async () => {
+      const contact = await factories.createContact({projectId});
+      const template = await factories.createTemplate({projectId, type: 'MARKETING'});
+      const email = await factories.createEmail(projectId, contact.id, {
+        templateId: template.id,
+        sourceType: EmailSourceType.TRANSACTIONAL,
+        status: EmailStatus.SENDING,
+      });
+      const submit = vi.fn().mockResolvedValue({messageId: 'ses-message-id'});
+
+      await prisma.contact.update({where: {id: contact.id}, data: {subscribed: false}});
+
+      const result = await submitEmailWithSubscriptionCheck(
+        {
+          emailId: email.id,
+          sourceType: EmailSourceType.TRANSACTIONAL,
+          templateType: 'MARKETING',
+          hasRecipientOverride: false,
+        },
+        submit,
+      );
+
+      expect(result).toEqual({submitted: false});
+      expect(submit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/jobs/email-processor.ts
+++ b/apps/api/src/jobs/email-processor.ts
@@ -10,7 +10,7 @@
  * doing before this logic is next changed.
  */
 
-import {EmailStatus} from '@plunk/db';
+import {EmailSourceType, EmailStatus, type TemplateType} from '@plunk/db';
 import type {SendEmailJobData} from '@plunk/types';
 import {type Job, Worker} from 'bullmq';
 import signale from 'signale';
@@ -81,6 +81,66 @@ function deriveWorkerConcurrency(rateLimit: number): number {
   const MIN_CONCURRENCY = 5;
   const derived = Math.ceil(rateLimit * TARGET_JOB_SECONDS);
   return Math.max(MIN_CONCURRENCY, Math.min(derived, EMAIL_WORKER_MAX_CONCURRENCY));
+}
+
+const UNSUBSCRIBED_ERROR = 'Contact is unsubscribed from marketing emails';
+
+/**
+ * Re-read subscription state at the last possible point before handing a
+ * marketing email to SES. The email may have waited in Redis after the earlier
+ * enqueue-time check, so the contact bundled into the initial worker query can
+ * already be stale.
+ */
+export async function submitEmailWithSubscriptionCheck<T>(
+  params: {
+    emailId: string;
+    sourceType: EmailSourceType;
+    templateType?: TemplateType | null;
+    hasRecipientOverride: boolean;
+  },
+  submit: () => Promise<T>,
+): Promise<{submitted: false} | {submitted: true; result: T}> {
+  // Source type carries the transactional exemption. A MARKETING template is
+  // the one deliberate override: the transactional API rejects that template
+  // for an unsubscribed contact, so the backlog check must preserve the same
+  // policy if the contact unsubscribes after enqueueing.
+  const requiresSubscription =
+    !params.hasRecipientOverride &&
+    (params.sourceType !== EmailSourceType.TRANSACTIONAL || params.templateType === 'MARKETING');
+
+  if (requiresSubscription) {
+    const latestEmail = await prisma.email.findUnique({
+      where: {id: params.emailId},
+      select: {
+        contact: {
+          select: {
+            email: true,
+            subscribed: true,
+          },
+        },
+      },
+    });
+
+    if (!latestEmail) {
+      throw new Error(`Email ${params.emailId} not found during subscription check`);
+    }
+
+    if (!latestEmail.contact.subscribed) {
+      signale.warn(
+        `[EMAIL-PROCESSOR] Skipping marketing email ${params.emailId} to unsubscribed contact ${latestEmail.contact.email}`,
+      );
+      await prisma.email.update({
+        where: {id: params.emailId},
+        data: {
+          status: EmailStatus.FAILED,
+          error: UNSUBSCRIBED_ERROR,
+        },
+      });
+      return {submitted: false};
+    }
+  }
+
+  return {submitted: true, result: await submit()};
 }
 
 export async function createEmailWorker() {
@@ -241,22 +301,42 @@ export async function createEmailWorker() {
           throw new Error(`Project ${email.projectId} has been disabled due to a policy violation`);
         }
 
-        // Send via AWS SES
-        const result = await sendRawEmail({
-          from: {
-            name: fromName,
-            email: fromEmail,
+        // The contact may have unsubscribed while this job was waiting in Redis.
+        // Wrap the actual SES call so that the fresh subscription read and submit
+        // cannot accidentally drift apart later.
+        const submission = await submitEmailWithSubscriptionCheck(
+          {
+            emailId,
+            sourceType: email.sourceType,
+            templateType: email.template?.type,
+            hasRecipientOverride: Boolean(customHeaders?.['X-Plunk-Recipient-Override']),
           },
-          to: typeof recipient === 'string' ? [recipient] : [{name: recipient.name, email: recipient.email}],
-          content: {
-            subject: formattedEmail.subject,
-            html: compiledHtml,
-          },
-          reply: email.replyTo || undefined,
-          headers: outboundHeaders,
-          tracking: shouldTrack,
-          attachments: email.attachments as {filename: string; content: string; contentType: string}[] | null,
-        });
+          () =>
+            sendRawEmail({
+              from: {
+                name: fromName,
+                email: fromEmail,
+              },
+              to: typeof recipient === 'string' ? [recipient] : [{name: recipient.name, email: recipient.email}],
+              content: {
+                subject: formattedEmail.subject,
+                html: compiledHtml,
+              },
+              reply: email.replyTo || undefined,
+              headers: outboundHeaders,
+              tracking: shouldTrack,
+              attachments: email.attachments as {filename: string; content: string; contentType: string}[] | null,
+            }),
+        );
+
+        if (!submission.submitted) {
+          if (email.campaignId) {
+            await CampaignService.finalizeIfDone(email.campaignId);
+          }
+          return;
+        }
+
+        const {result} = submission;
 
         // Mark as sent with SES message ID.
         //


### PR DESCRIPTION
Queued marketing emails can outlive the subscription state checked when they were created. A contact who unsubscribes while an email waits in Redis can therefore still receive it.

This change re-reads the contact immediately before the SES call and suppresses the email when the latest state is unsubscribed. It preserves Plunk’s existing exemptions for transactional sends, headless transactional templates, and explicit recipient overrides. Marketing templates sent through the transactional endpoint remain subject to opt-out.

Verification:
- `yarn test:run apps/api/src/jobs/__tests__/email-processor.test.ts --maxWorkers=1` (15 tests)
- focused ESLint
- `yarn build --filter=api`

The final review noted the unavoidable gap between the database read and an external SES request. Holding a database lock across a network call would delay the unsubscribe transaction rather than make the two systems atomic, so this keeps the check at the last practical boundary before submission.